### PR TITLE
将账户迁移链接更换

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchRight.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchRight.xaml.vb
@@ -102,7 +102,7 @@
     Public Shared Sub StartMigration()
         MyMsgBox("在迁移过程中，你可能需要设置你的档案信息，此时请注意让年龄大于 18 岁，否则可能导致无法登录！" & vbCrLf &
                  "在迁移完成后，请在上方选择 微软 登录方式而非 Mojang。", "迁移提示", "继续", ForceWait:=True)
-        OpenWebsite("https://www.minecraft.net/zh-hans/account-security")
+        OpenWebsite("https://aka.ms/MinecraftMigration")
     End Sub
 
 End Class


### PR DESCRIPTION
# 更换理由
1.官方游戏启动器的迁移链接正是使用了该地址，我们应该顺从
2.原来的链接有点难打开，替换的链接打开很顺畅