### PR TITLE
将 Minecraftwiki的 fandom 链接换成 Biliwiki 链接

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.vb
+++ b/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.vb
@@ -305,7 +305,7 @@ Public Module ModDownloadLib
             Log("[Error] 未知的版本格式：" & Id & "。", LogLevel.Feedback)
             Exit Sub
         End If
-        OpenWebsite("https://wiki.biligame.com/mc/" & WikiName.Replace("_experimental-snapshot-", "-exp"))
+        OpenWebsite("https://searchwiki.biligame.com/mc/index.php?search=" & WikiName.Replace("_experimental-snapshot-", "-exp"))
     End Sub
 
 #End Region

--- a/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.vb
+++ b/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.vb
@@ -305,7 +305,7 @@ Public Module ModDownloadLib
             Log("[Error] 未知的版本格式：" & Id & "。", LogLevel.Feedback)
             Exit Sub
         End If
-        OpenWebsite("https://minecraft.fandom.com/zh/wiki/" & WikiName.Replace("_experimental-snapshot-", "-exp"))
+        OpenWebsite("https://wiki.biligame.com/mc/" & WikiName.Replace("_experimental-snapshot-", "-exp"))
     End Sub
 
 #End Region

--- a/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.vb
+++ b/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.vb
@@ -305,7 +305,7 @@ Public Module ModDownloadLib
             Log("[Error] 未知的版本格式：" & Id & "。", LogLevel.Feedback)
             Exit Sub
         End If
-        OpenWebsite("https://searchwiki.biligame.com/mc/index.php?search=" & WikiName.Replace("_experimental-snapshot-", "-exp"))
+        OpenWebsite("https://wiki.biligame.com/mc/" & WikiName.Replace("_experimental-snapshot-", "-exp"))
     End Sub
 
 #End Region


### PR DESCRIPTION
fandom的速度挺慢的，bilibiliwiki似乎挺不错的
格式应该都是支持的
~链接换成搜索的链接是因为，搜索页面会检测搜索的内容是否是某个页面的id，如果相似或相同，就会自动跳转，所以没有必要自动转换（不删掉的原因是怕搞出啥问题，而且也不会影响到啥）~