### PR TITLE
优化 综合 Bug 反馈 模板

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug9.yml
+++ b/.github/ISSUE_TEMPLATE/bug9.yml
@@ -9,6 +9,7 @@ body:
     description: "请逐个检查下列项目，并勾选确认。"
     options:
     - label: "我已点击 `设置 → 启动器 → 检查更新` 确认了启动器已为最新版，且最新版未修复这个 Bug。[怎样更新？](https://shimo.im/docs/qKPttVvXKqPD8YDC#anchor-oTgb)"
+      required: false
     - label: "我已在 [Issues 页面](https://github.com/Hex-Dragon/PCL2/issues?q=is%3Aissue+) 中搜索，确认了这一 Bug 未被提交过。"
       required: true
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug9.yml
+++ b/.github/ISSUE_TEMPLATE/bug9.yml
@@ -9,7 +9,6 @@ body:
     description: "请逐个检查下列项目，并勾选确认。"
     options:
     - label: "我已点击 `设置 → 启动器 → 检查更新` 确认了启动器已为最新版，且最新版未修复这个 Bug。[怎样更新？](https://shimo.im/docs/qKPttVvXKqPD8YDC#anchor-oTgb)"
-      required: true
     - label: "我已在 [Issues 页面](https://github.com/Hex-Dragon/PCL2/issues?q=is%3Aissue+) 中搜索，确认了这一 Bug 未被提交过。"
       required: true
 - type: textarea


### PR DESCRIPTION
只是针对一个小细节进行了一个小更改，如果感觉没太大必要还请麻烦关掉吧~ 🧐谢谢~

当遇到启动器无法更新等问题时*，反馈者可能无法完成第一项检查项的检查工作，但不勾选还交不了 Issue，这就使得反馈者必须在下方评论说明或对提交完毕的 Issue 进行手动修改。所以只在这个 Issue 模板中让这个检查项不是必选的，其他模板不变，可能交反馈时会方便点🤔🤔

###### *注：不论是启动器的问题还是反馈者的问题，总是会出现此类反馈，因此个人感觉还是稍微有那么一点点必要的（