### PR TITLE
阻止与联机相关页面的直接跳转

### DIFF
--- a/Plain Craft Launcher 2/FormMain.xaml.vb
+++ b/Plain Craft Launcher 2/FormMain.xaml.vb
@@ -1255,11 +1255,9 @@ Install:
             End Select
             '阻拦直接通过已知可跳转的 EventType 跳转至联机页面
             '(存在疑问：是复用 CancelLink() 方法还是直接写 MyMsgBox 更合适？)
-            If Stack == 2 Then
-                If SubType == 4 Or SubType == 6 Then
-                    CancelLink() '需要确认其用法
-                End If
-            ElseIf Stack == 3 And SubType == 3 Then
+            If Stack == 2 Then 'Link/* 联机相关主页面阻断
+                CancelLink() '需要确认其用法
+            ElseIf Stack == 3 And SubType == 3 Then 'Setup/SetupLink 联机设置阻断
                 CancelLink() '需要确认其用法
             Else
                 PageChangeActual(Stack, SubType)

--- a/Plain Craft Launcher 2/FormMain.xaml.vb
+++ b/Plain Craft Launcher 2/FormMain.xaml.vb
@@ -1253,7 +1253,17 @@ Install:
                     If FrmVersionLeft Is Nothing Then FrmVersionLeft = New PageVersionLeft
                     CType(FrmVersionLeft.PanItem.Children(SubType), MyListItem).SetChecked(True, True, Stack = PageCurrent)
             End Select
-            PageChangeActual(Stack, SubType)
+            '阻拦直接通过已知可跳转的 EventType 跳转至联机页面
+            '(存在疑问：是复用 CancelLink() 方法还是直接写 MyMsgBox 更合适？)
+            If Stack == 2 Then
+                If SubType == 4 Or SubType == 6 Then
+                    CancelLink() '需要确认其用法
+                End If
+            ElseIf Stack == 3 And SubType == 3 Then
+                CancelLink() '需要确认其用法
+            Else
+                PageChangeActual(Stack, SubType)
+            End If
         End If
     End Sub
     ''' <summary>


### PR DESCRIPTION
fix #2784.
在跳转前检查页面对应的类别，若与联机相关则直接阻断并弹窗。
(无法确定 CancelLink() 具体怎么用，参数留了空Orz)