### PR TITLE
`https://minecraft.fandom.com/zh/wiki/` -> `https://zh.minecraft.wiki/w/`

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.vb
+++ b/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.vb
@@ -309,7 +309,7 @@ Public Module ModDownloadLib
             Log("[Error] 未知的版本格式：" & Id & "。", LogLevel.Feedback)
             Exit Sub
         End If
-        OpenWebsite("https://minecraft.fandom.com/zh/wiki/" & WikiName.Replace("_experimental-snapshot-", "-exp"))
+        OpenWebsite("https://zh.minecraft.wiki/w/" & WikiName.Replace("_experimental-snapshot-", "-exp"))
     End Sub
 
 #End Region


### PR DESCRIPTION
已测试 URL 规则能在新的 https://zh.minecraft.wiki/w/ 中使用

fix https://github.com/Hex-Dragon/PCL2/issues/2865

如果要改些什么的话，得等到星期五那晚（