### PR TITLE
替换前往github的链接

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageOther/PageOtherLeft.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageOther/PageOtherLeft.xaml.vb
@@ -127,18 +127,18 @@
     '打开网页
     Public Shared Sub TryFeedback() Handles ItemFeedback.Click
         If Not CanFeedback(True) Then Exit Sub
-        Select Case MyMsgBox("是否要打开反馈列表网页？" & vbCrLf & "如果无法打开该网页，请尝试使用加速器或 VPN。",
+        Select Case MyMsgBox("是否要打开反馈列表网页？" & vbCrLf & "如果无法打开该网页，请尝试关闭加速器或 VPN。",
                     "反馈提示", "提交新反馈", "查看反馈列表", "取消")
             Case 1
                 Feedback(True, False)
             Case 2
-                OpenWebsite("https://github.com/Hex-Dragon/PCL2/issues/")
+                OpenWebsite("https://githubfast.com/Hex-Dragon/PCL2/issues/")
         End Select
     End Sub
     Public Shared Sub TryVote() Handles ItemVote.Click
-        If MyMsgBox("是否要打开新功能投票网页？" & vbCrLf & "如果无法打开该网页，请尝试使用加速器或 VPN。",
+        If MyMsgBox("是否要打开新功能投票网页？" & vbCrLf & "如果无法打开该网页，请尝试关闭加速器或 VPN。",
                     "提醒", "打开", "取消") = 2 Then Exit Sub
-        OpenWebsite("https://github.com/Hex-Dragon/PCL2/discussions/categories/%E5%8A%9F%E8%83%BD%E6%8A%95%E7%A5%A8?discussions_q=category%3A%E5%8A%9F%E8%83%BD%E6%8A%95%E7%A5%A8+sort%3Adate_created")
+        OpenWebsite("https://githubfast.com/Hex-Dragon/PCL2/discussions/categories/%E5%8A%9F%E8%83%BD%E6%8A%95%E7%A5%A8?discussions_q=category%3A%E5%8A%9F%E8%83%BD%E6%8A%95%E7%A5%A8+sort%3Adate_created")
     End Sub
 
 End Class


### PR DESCRIPTION
在国内，githubfast.com的访问比github.com快得多，至少在不使用《加速器或VPN》的情况下是这样的......
githubfast.com几乎与github.com完全一致，甚至只需要在任何github链接中的“github”后面加.com就行了......
然而，在开着《加速器或VPN》的情况下，访问githubfast.com会特别慢，所以建议用户把《加速器或VPN》关掉

*额我对代码没有任何了解，我只会把我认识的东西改掉.jpg
如果有语法错误的话，还是请大佬来吧(* 