### PR TITLE
添加自定义主页预设误反馈检查项

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug9.yml
+++ b/.github/ISSUE_TEMPLATE/bug9.yml
@@ -10,6 +10,8 @@ body:
     options:
     - label: "我已在 [Issues 页面](https://github.com/Hex-Dragon/PCL2/issues?q=is%3Aissue+) 和 [常见&难检反馈及问题列表](https://github.com/Hex-Dragon/PCL2/discussions/1930) 中搜索，确认了这一 Bug 未被提交过。"
       required: true
+    - label: "我已知晓若是自定义主页预设出现的问题，并非 PCL 的问题，**不应在这里提交反馈**，而应去该主页作者的项目仓库进行反馈。"
+      required: true
 - type: textarea
   id: "yml-2"
   attributes:


### PR DESCRIPTION
“历史上的今天” 主页常出现编码问题，导致较多反馈者往 PCL2 仓库砸反馈，加一条至少可以减少一点此类反馈。在其他主页出现问题时也可以预防反馈者错误地在 PCL2 仓库提交反馈，毕竟这不是 PCL2 的问题。