### PR TITLE
反馈bug的issue模板增加填写使用版本号的文本框

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug1.yml
+++ b/.github/ISSUE_TEMPLATE/bug1.yml
@@ -15,21 +15,21 @@ body:
     - label: "我已在 [Issues 页面](https://github.com/Hex-Dragon/PCL2/issues?q=is%3Aissue+) 和 [常见&难检反馈及问题列表](https://github.com/Hex-Dragon/PCL2/discussions/1930) 中搜索，确认了这一 Bug 未被提交过。"
       required: true
 - type: textarea
-  id: "yml-5"
+  id: "yml-2"
   attributes:
     label: 版本号
     description: "填写具体的版本号，例如：Release 2.7.1 (注意“最新版”并不是一个正确的版本号)"
   validations:
     required: true
 - type: textarea
-  id: "yml-2"
+  id: "yml-3"
   attributes:
     label: 描述
     description: "详细描述具体表现。"
   validations:
     required: true
 - type: textarea
-  id: "yml-3"
+  id: "yml-4"
   attributes:
     label: PCL 错误报告、日志与附件
     description: "上传 PCL 提供的错误报告（在崩溃时选择导出错误报告）。如果没有，也可以上传 PCL 文件夹中的 Log1~5.txt。"
@@ -37,7 +37,7 @@ body:
   validations:
     required: true
 - type: textarea
-  id: "yml-4"
+  id: "yml-5"
   attributes:
     label: HMCL 启动脚本
     description: "在 HMCL 中进入版本列表，点击版本右侧的三个点，选择 生成启动脚本。"

--- a/.github/ISSUE_TEMPLATE/bug1.yml
+++ b/.github/ISSUE_TEMPLATE/bug1.yml
@@ -15,6 +15,13 @@ body:
     - label: "我已在 [Issues 页面](https://github.com/Hex-Dragon/PCL2/issues?q=is%3Aissue+) 和 [常见&难检反馈及问题列表](https://github.com/Hex-Dragon/PCL2/discussions/1930) 中搜索，确认了这一 Bug 未被提交过。"
       required: true
 - type: textarea
+  id: "yml-5"
+  attributes:
+    label: 版本号
+    description: "填写具体的版本号，例如：Release 2.7.1 (注意“最新版”并不是一个正确的版本号)"
+  validations:
+    required: true
+- type: textarea
   id: "yml-2"
   attributes:
     label: 描述

--- a/.github/ISSUE_TEMPLATE/bug2.yml
+++ b/.github/ISSUE_TEMPLATE/bug2.yml
@@ -17,12 +17,19 @@ body:
 - type: textarea
   id: "yml-2"
   attributes:
+    label: 版本号
+    description: "填写具体的版本号，例如：Release 2.7.1 (注意“最新版”并不是一个正确的版本号)"
+  validations:
+    required: true
+- type: textarea
+  id: "yml-3"
+  attributes:
     label: 描述
     description: "详细描述该 Bug 的具体表现。"
   validations:
     required: true
 - type: textarea
-  id: "yml-3"
+  id: "yml-4"
   attributes:
     label: 重现步骤
     description: "详细描述要怎么操作才能再次触发这个 Bug。"

--- a/.github/ISSUE_TEMPLATE/bug2.yml
+++ b/.github/ISSUE_TEMPLATE/bug2.yml
@@ -39,7 +39,7 @@ body:
   validations:
     required: true
 - type: textarea
-  id: "yml-4"
+  id: "yml-5"
   attributes:
     label: 日志与附件
     description: "上传 PCL 文件夹中的 Log1~5.txt。[日志在哪？](https://shimo.im/docs/qKPttVvXKqPD8YDC#anchor-fvZW)"

--- a/.github/ISSUE_TEMPLATE/bug9.yml
+++ b/.github/ISSUE_TEMPLATE/bug9.yml
@@ -13,12 +13,19 @@ body:
 - type: textarea
   id: "yml-2"
   attributes:
+    label: 版本号
+    description: "填写具体的版本号，例如：Release 2.7.1 (注意“最新版”并不是一个正确的版本号)"
+  validations:
+    required: true
+- type: textarea
+  id: "yml-3"
+  attributes:
     label: 描述
     description: "详细描述该 Bug 的具体表现。"
   validations:
     required: true
 - type: textarea
-  id: "yml-3"
+  id: "yml-4"
   attributes:
     label: 重现步骤
     description: "详细描述要怎么操作才能再次触发这个 Bug。"
@@ -28,7 +35,7 @@ body:
   validations:
     required: true
 - type: textarea
-  id: "yml-4"
+  id: "yml-5"
   attributes:
     label: 日志与附件
     description: "上传 PCL 文件夹中的 Log1~5.txt。[日志在哪？](https://shimo.im/docs/qKPttVvXKqPD8YDC#anchor-fvZW)"


### PR DESCRIPTION
resolved #3654 
依稀记得好像之前issue编号才一两千的时候也出过类似的issue？时间太久远找不到了，有人提就顺手pr了，解决了该issue提到的日志里的版本号不显眼的问题，也有利于collaborator快速比对版本号并要求反馈者使用最新版测试