### PR TITLE
修复硬编码要求 http 开头链接导致 #3985

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,15 +25,15 @@ jobs:
       # 定义矩阵，矩阵中每组都会单独执行，并使矩阵本身成为可用的上下文
       matrix:
         include: 
-        - name: Debug
+        - name: 开发版
           configuration: Debug
-        - name: DebugSnapshot
+        - name: 开发版
           configuration: Snapshot
-        - name: Release
+        - name: 快照版
           configuration: Release
-        - name: ReleaseUpdate
+        - name: 快照版
           configuration: ReleaseUpdate
-        - name: Beta
+        - name: 正式版
           configuration: BETA
           
     # 显然，只有Windows才能构建.NET Framework程序

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,15 +25,15 @@ jobs:
       # 定义矩阵，矩阵中每组都会单独执行，并使矩阵本身成为可用的上下文
       matrix:
         include: 
-        - name: 开发版
+        - name: Debug
           configuration: Debug
-        - name: 开发版
+        - name: DebugSnapshot
           configuration: Snapshot
-        - name: 快照版
+        - name: Release
           configuration: Release
-        - name: 快照版
+        - name: ReleaseUpdate
           configuration: ReleaseUpdate
-        - name: 正式版
+        - name: Beta
           configuration: BETA
           
     # 显然，只有Windows才能构建.NET Framework程序

--- a/Plain Craft Launcher 2/Modules/Base/ModBase.vb
+++ b/Plain Craft Launcher 2/Modules/Base/ModBase.vb
@@ -2186,11 +2186,11 @@ NextElement:
     ''' </summary>
     Public Sub OpenWebsite(Url As String)
         Try
-            Log("[System] 正在打开网页：" & Url)  
+            Log("[System] 正在打开链接：" & Url)  
             Process.Start(Url) 
         Catch ex As Exception  
              
-            Log(ex, "无法打开URL（" & Url & "）")  
+            Log(ex, "无法打开链接（" & Url & "）")  
             ClipboardSet(Url, False)  
             MyMsgBox("可能由于系统未配置相应的应用，PCL 无法为你打开这个链接。" & vbCrLf &  
                     "链接已经复制到剪贴板，若有需要可以手动粘贴访问。" & vbCrLf &  

--- a/Plain Craft Launcher 2/Modules/Base/ModBase.vb
+++ b/Plain Craft Launcher 2/Modules/Base/ModBase.vb
@@ -2186,14 +2186,15 @@ NextElement:
     ''' </summary>
     Public Sub OpenWebsite(Url As String)
         Try
-            If Not Url.StartsWithF("http", True) Then Throw New Exception(Url & " 不是一个有效的网址，它必须以 http 开头！")
-            Log("[System] 正在打开网页：" & Url)
-            Process.Start(Url)
-        Catch ex As Exception
-            Log(ex, "无法打开网页（" & Url & "）")
-            ClipboardSet(Url, False)
-            MyMsgBox("可能由于浏览器未正确配置，PCL 无法为你打开网页。" & vbCrLf & "网址已经复制到剪贴板，若有需要可以手动粘贴访问。" & vbCrLf &
-                     $"网址：{Url}", "无法打开网页")
+            Log("[System] 正在打开网页：" & Url)  
+            Process.Start(Url) 
+        Catch ex As Exception  
+             
+            Log(ex, "无法打开URL（" & Url & "）")  
+            ClipboardSet(Url, False)  
+            MyMsgBox("可能由于系统未配置相应的应用，PCL 无法为你打开这个链接。" & vbCrLf &  
+                    "链接已经复制到剪贴板，若有需要可以手动粘贴访问。" & vbCrLf &  
+                    $"链接：{Url}", "无法打开链接") 
         End Try
     End Sub
     ''' <summary>


### PR DESCRIPTION
Fix #3985 
考虑到预设和网络自定义后续可能会指定多种格式的链接头，故删去强制 http 开头链接要求而不是对 minecraft:// 链接头做识别和跳过

已通过 Action 确认可编译

https://github.com/wuliaodexiaoluo/PCL2/actions/runs/9436291564