### PR TITLE
单独兼容打开网址 `minecraft://`

### DIFF
--- a/Plain Craft Launcher 2/Modules/Base/ModBase.vb
+++ b/Plain Craft Launcher 2/Modules/Base/ModBase.vb
@@ -2186,7 +2186,7 @@ NextElement:
     ''' </summary>
     Public Sub OpenWebsite(Url As String)
         Try
-            If Not Url.StartsWithF("http", True) Then Throw New Exception(Url & " 不是一个有效的网址，它必须以 http 开头！")
+            If Not Url.StartsWithF("http", True) Or Url = "minecraft://" Then Throw New Exception(Url & " 不是一个有效的网址，它必须以 http 开头！")
             Log("[System] 正在打开网页：" & Url)
             Process.Start(Url)
         Catch ex As Exception

--- a/Plain Craft Launcher 2/Modules/Base/ModBase.vb
+++ b/Plain Craft Launcher 2/Modules/Base/ModBase.vb
@@ -2185,16 +2185,22 @@ NextElement:
     ''' 打开网页。
     ''' </summary>
     Public Sub OpenWebsite(Url As String)
-        Try
-            If Not Url.StartsWithF("http", True) Or Url = "minecraft://" Then Throw New Exception(Url & " 不是一个有效的网址，它必须以 http 开头！")
-            Log("[System] 正在打开网页：" & Url)
-            Process.Start(Url)
-        Catch ex As Exception
-            Log(ex, "无法打开网页（" & Url & "）")
-            ClipboardSet(Url, False)
-            MyMsgBox("可能由于浏览器未正确配置，PCL 无法为你打开网页。" & vbCrLf & "网址已经复制到剪贴板，若有需要可以手动粘贴访问。" & vbCrLf &
-                     $"网址：{Url}", "无法打开网页")
-        End Try
+        ' 允许 Minecraft 基岩版的 URLScheme (#3985)
+        If Url.StartsWithF("minecraft", True) Then
+            ' 一定会被捕捉到错误，单独拎出来
+            Process.Start("minecraft://")
+        Else
+            Try
+                If Not Url.StartsWithF("http", True) Then Throw New Exception(Url & " 不是一个有效的网址，它必须以 http 开头！")
+                Log("[System] 正在打开网页：" & Url)
+                Process.Start(Url)
+            Catch ex As Exception
+                Log(ex, "无法打开网页（" & Url & "）")
+                ClipboardSet(Url, False)
+                MyMsgBox("可能由于浏览器未正确配置，PCL 无法为你打开网页。" & vbCrLf & "网址已经复制到剪贴板，若有需要可以手动粘贴访问。" & vbCrLf &
+                         $"网址：{Url}", "无法打开网页")
+            End Try
+        End If
     End Sub
     ''' <summary>
     ''' 打开 explorer。注意参数中的路径要尽量加上双引号！


### PR DESCRIPTION
仅对 `minecraft://` 做了单独处理，其他的还是原来的规则