### PR TITLE
尝试修复 1.8 和 1.9 的 Optifine 列表问题

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.vb
+++ b/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.vb
@@ -319,6 +319,10 @@ Public Module ModDownloadLib
     Public Sub McDownloadOptiFine(DownloadInfo As DlOptiFineListEntry)
         Try
             Dim Id As String = DownloadInfo.NameVersion
+            'OptiFine 1.8 和 1.9 版本的版本列表存在问题，需要补 0 才能获取到对应版本
+            If Id = "1.9" OrElse Id = "1.8" Then
+                Id = Id & ".0"
+            End If
             Dim VersionFolder As String = PathMcFolder & "versions\" & Id & "\"
             Dim IsNewVersion As Boolean = Val(DownloadInfo.Inherit.Split(".")(1)) >= 14
             Dim Target As String = If(IsNewVersion,


### PR DESCRIPTION
据 OpenBMCLAPI 成员反馈，Optifine 的分版本列表中将 1.8 和 1.9 分别标记为（实际上是错误的，但它就是这么写的） 1.8.0 和 1.9.0，导致安装整合包时可能无法正确下载上述两个版本的 Optifine。

具体地，安装整合包时，启动器会尝试请求`/optifine/1.8`，从而获取到空列表。而正确的列表是`/optifine/1.8.0`

此 PR 旨在尝试处理该问题，但具体的解决方式没有经过严格测试，供参考。