### PR TITLE
完成 #3997 允许启动当前版本

### DIFF
--- a/Plain Craft Launcher 2/Modules/ModEvent.vb
+++ b/Plain Craft Launcher 2/Modules/ModEvent.vb
@@ -43,7 +43,7 @@
                                 End Sub)
 
                 Case "启动游戏"
-                    If Data(0) = "$mcv" Then Data(0) = McVersionCurrent.Name
+                    If Data(0) = "\current" Then Data(0) = McVersionCurrent.Name
                     If McLaunchStart(New McLaunchOptions With
                                      {.ServerIp = If(Data.Length >= 2, Data(1), Nothing), .Version = New McVersion(Data(0))}) Then
                         Hint("正在启动 " & Data(0) & "……")

--- a/Plain Craft Launcher 2/Modules/ModEvent.vb
+++ b/Plain Craft Launcher 2/Modules/ModEvent.vb
@@ -43,6 +43,7 @@
                                 End Sub)
 
                 Case "启动游戏"
+                    If Data(0) = "$mcv" Then Data(0) = McVersionCurrent.Name
                     If McLaunchStart(New McLaunchOptions With
                                      {.ServerIp = If(Data.Length >= 2, Data(1), Nothing), .Version = New McVersion(Data(0))}) Then
                         Hint("正在启动 " & Data(0) & "……")

--- a/Plain Craft Launcher 2/Modules/ModMain.vb
+++ b/Plain Craft Launcher 2/Modules/ModMain.vb
@@ -665,7 +665,6 @@ NextFile:
         Dim Result = Xaml.Replace("{path}", EscapeXML(Path))
         Result = RegexReplaceEach(Result, Function() EscapeXML(PageOtherTest.GetRandomHint()), "\{hint\}")
         Result = RegexReplaceEach(Result, Function() EscapeXML(PageOtherTest.GetRandomCave()), "\{cave\}")
-        Result = Result.Replace("{mcv}", "$mcv") '不知道为啥，实例化 {mcv} 有可能会炸掉，只能先把它换掉，再换成版本名
         Return Result
     End Function
 

--- a/Plain Craft Launcher 2/Modules/ModMain.vb
+++ b/Plain Craft Launcher 2/Modules/ModMain.vb
@@ -665,6 +665,7 @@ NextFile:
         Dim Result = Xaml.Replace("{path}", EscapeXML(Path))
         Result = RegexReplaceEach(Result, Function() EscapeXML(PageOtherTest.GetRandomHint()), "\{hint\}")
         Result = RegexReplaceEach(Result, Function() EscapeXML(PageOtherTest.GetRandomCave()), "\{cave\}")
+        Result = Result.Replace("{mcv}", "$mcv") '不知道为啥，实例化 {mcv} 有可能会炸掉，只能先把它换掉，再换成版本名
         Return Result
     End Function
 

--- a/Plain Craft Launcher 2/Resources/Custom.xaml
+++ b/Plain Craft Launcher 2/Resources/Custom.xaml
@@ -81,9 +81,9 @@
 		<local:MyButton Margin="0,4,0,0" Width="250" Height="35"
                     Text="启动 1.12.2 并进入 Hypixel" EventType="启动游戏" EventData="1.12.2|mc.hypixel.net" ToolTip="服务器 IP：mc.hypixel.net" />
 		<TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
-                    Text="使用 {mcver} 可以表示当前被选中的游戏版本，但请注意，这只在 EventData 属性中有效。" />
+                    Text="在 EventData 中填写 \current，表示启动当前被选中的游戏版本，同样可以在后面填写服务器 IP。" />
 		<local:MyButton Margin="0,4,0,10" Width="250" Height="35"
-                    Text="启动当前选中版本并进入 Hypixel" EventType="启动游戏" EventData="{mcver}|mc.hypixel.net" ToolTip="服务器 IP：mc.hypixel.net" />
+                    Text="启动当前选中版本并进入 Hypixel" EventType="启动游戏" EventData="\current|mc.hypixel.net" ToolTip="服务器 IP：mc.hypixel.net" />
 	</StackPanel>
 </local:MyCard>
 

--- a/Plain Craft Launcher 2/Resources/Custom.xaml
+++ b/Plain Craft Launcher 2/Resources/Custom.xaml
@@ -80,6 +80,10 @@
                     Text="在 EventData 后面添加一条竖线（|），竖线后填写服务器 IP，即可在启动该版本的同时自动进入服务器。" />
 		<local:MyButton Margin="0,4,0,0" Width="250" Height="35"
                     Text="启动 1.12.2 并进入 Hypixel" EventType="启动游戏" EventData="1.12.2|mc.hypixel.net" ToolTip="服务器 IP：mc.hypixel.net" />
+		<TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
+                    Text="使用 “花括号 mcv” 可以表示当前被选中的游戏版本，但请注意，这只在 EventData 属性中有效。" />
+		<local:MyButton Margin="0,4,0,10" Width="250" Height="35"
+                    Text="启动当前选中版本并进入 Hypixel" EventType="启动游戏" EventData="{mcv}|mc.hypixel.net" ToolTip="服务器 IP：mc.hypixel.net" />
 	</StackPanel>
 </local:MyCard>
 

--- a/Plain Craft Launcher 2/Resources/Custom.xaml
+++ b/Plain Craft Launcher 2/Resources/Custom.xaml
@@ -81,9 +81,9 @@
 		<local:MyButton Margin="0,4,0,0" Width="250" Height="35"
                     Text="启动 1.12.2 并进入 Hypixel" EventType="启动游戏" EventData="1.12.2|mc.hypixel.net" ToolTip="服务器 IP：mc.hypixel.net" />
 		<TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
-                    Text="使用 “花括号 mcv” 可以表示当前被选中的游戏版本，但请注意，这只在 EventData 属性中有效。" />
+                    Text="使用 {mcver} 可以表示当前被选中的游戏版本，但请注意，这只在 EventData 属性中有效。" />
 		<local:MyButton Margin="0,4,0,10" Width="250" Height="35"
-                    Text="启动当前选中版本并进入 Hypixel" EventType="启动游戏" EventData="{mcv}|mc.hypixel.net" ToolTip="服务器 IP：mc.hypixel.net" />
+                    Text="启动当前选中版本并进入 Hypixel" EventType="启动游戏" EventData="{mcver}|mc.hypixel.net" ToolTip="服务器 IP：mc.hypixel.net" />
 	</StackPanel>
 </local:MyCard>
 


### PR DESCRIPTION
Close #3997

检索式：`is:pr (当前版本 AND 服务器) OR 4002 OR 3997`

顺便把教学文件也改了……

https://github.com/Hex-Dragon/PCL2/pull/4060#issuecomment-2177755361

---

**（以下内容已失效，仅供存档）**

目前设计是启动游戏时直接把 `{mcv}` 替换掉，但是不知道为啥，傻逼 WPF 实例化 `{mcv}` 这几个字符的时候直接炸了……

所以主页加载的时候， `{mcv}` 会变成 `$mcv` 防止爆炸……但是这样的话，TextBlock 里面如果出现 `{mcv}` 会变得很奇怪……

我想问问能不能*在主页加载时*进行如下替换：`EventData="{mcv}` -> `EventData="$mcv`

或者……重新弄一个 EventType……？