### PR TITLE
添加 .gitignore & 让工作流编译支持替换 client_id 和 x-api-key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,15 @@ jobs:
       with:
         msbuild-architecture: x64
 
+    - name: Replace
+      shell: powershell
+      env:
+        client_id: ${{ secrets.client_id }}
+        x-api-key: ${{ secrets.x_api_key }}
+      run: |
+        (gc "Plain Craft Launcher 2\Modules\ModSecret.vb") -replace '$client_id',   | Out-File "Plain Craft Launcher 2\Modules\ModSecret.vb"
+        (gc "Plain Craft Launcher 2\Modules\ModSecret.vb") -replace 'Client.Headers("x-api-key") = ""', '"Client.Headers("x-api-key") = ""' | Out-File "Plain Craft Launcher 2\Modules\ModSecret.vb"
+        (gc "Plain Craft Launcher 2\Modules\ModSecret.vb") -replace '$client_id',  | Out-File "Plain Craft Launcher 2\Modules\ModSecret.vb"
     - name: Build
       run: msbuild "Plain Craft Launcher 2\Plain Craft Launcher 2.vbproj" -p:Configuration=${{ matrix.configuration }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,9 +41,9 @@ jobs:
     - name: Replace
       shell: powershell
       run: |
-        (gc "Plain Craft Launcher 2\Modules\Minecraft\ModLaunch.vb") -replace 'Dim ClientId As String = ""', 'Dim ClientId As String = "${{ secrets.client_id }}"' | Out-File "Plain Craft Launcher 2\Modules\Minecraft\ModLaunch.vb"
-        (gc "Plain Craft Launcher 2\Modules\ModSecret.vb") -replace 'Client.Headers("x-api-key") = ""', '"Client.Headers("x-api-key") = "${{ secrets.x_api_key }}"' | Out-File "Plain Craft Launcher 2\Modules\ModSecret.vb"
-        (gc "Plain Craft Launcher 2\Modules\ModSecret.vb") -replace 'Request.Headers("x-api-key") = ""', 'Request.Headers("x-api-key") = "${{ secrets.x_api_key }}"' | Out-File "Plain Craft Launcher 2\Modules\ModSecret.vb"
+        (gc "Plain Craft Launcher 2\Modules\Minecraft\ModLaunch.vb") -replace 'Dim ClientId As String = ""', 'Dim ClientId As String = "${{ secrets.CLIENT_ID }}"' | Out-File "Plain Craft Launcher 2\Modules\Minecraft\ModLaunch.vb"
+        (gc "Plain Craft Launcher 2\Modules\ModSecret.vb") -replace 'Client.Headers\("x-api-key"\) = ""', 'Client.Headers("x-api-key") = "${{ secrets.X_API_KEY }}"' | Out-File "Plain Craft Launcher 2\Modules\ModSecret.vb"
+        (gc "Plain Craft Launcher 2\Modules\ModSecret.vb") -replace 'Request.Headers\("x-api-key"\) = ""', 'Request.Headers("x-api-key") = "${{ secrets.X_API_KEY }}"' | Out-File "Plain Craft Launcher 2\Modules\ModSecret.vb"
 
     - name: Build
       run: msbuild "Plain Craft Launcher 2\Plain Craft Launcher 2.vbproj" -p:Configuration=${{ matrix.configuration }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,11 +40,8 @@ jobs:
 
     - name: Replace
       shell: powershell
-      env:
-        client_id: ${{ secrets.client_id }}
-        x-api-key: ${{ secrets.x_api_key }}
       run: |
-        (gc "Plain Craft Launcher 2\Modules\ModSecret.vb") -replace 'Dim Client_id = ""', 'Dim Client_id = "${{ secrets.client_id }}"' | Out-File "Plain Craft Launcher 2\Modules\ModLaunch.vb"
+        (gc "Plain Craft Launcher 2\Modules\Minecraft\ModLaunch.vb") -replace 'Dim ClientId As String = ""', 'Dim ClientId As String = "${{ secrets.client_id }}"' | Out-File "Plain Craft Launcher 2\Modules\Minecraft\ModLaunch.vb"
         (gc "Plain Craft Launcher 2\Modules\ModSecret.vb") -replace 'Client.Headers("x-api-key") = ""', '"Client.Headers("x-api-key") = "${{ secrets.x_api_key }}"' | Out-File "Plain Craft Launcher 2\Modules\ModSecret.vb"
         (gc "Plain Craft Launcher 2\Modules\ModSecret.vb") -replace 'Request.Headers("x-api-key") = ""', 'Request.Headers("x-api-key") = "${{ secrets.x_api_key }}"' | Out-File "Plain Craft Launcher 2\Modules\ModSecret.vb"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,9 +44,9 @@ jobs:
         client_id: ${{ secrets.client_id }}
         x-api-key: ${{ secrets.x_api_key }}
       run: |
-        (gc "Plain Craft Launcher 2\Modules\ModSecret.vb") -replace '$client_id',   | Out-File "Plain Craft Launcher 2\Modules\ModSecret.vb"
+        (gc "Plain Craft Launcher 2\Modules\ModSecret.vb") -replace 'Dim Client_id = ""', 'Dim Client_id = "${{ secrets.client_id }}"' | Out-File "Plain Craft Launcher 2\Modules\ModLaunch.vb"
         (gc "Plain Craft Launcher 2\Modules\ModSecret.vb") -replace 'Client.Headers("x-api-key") = ""', '"Client.Headers("x-api-key") = "${{ secrets.x_api_key }}"' | Out-File "Plain Craft Launcher 2\Modules\ModSecret.vb"
-        (gc "Plain Craft Launcher 2\Modules\ModSecret.vb") -replace '$client_id',  | Out-File "Plain Craft Launcher 2\Modules\ModSecret.vb"
+        (gc "Plain Craft Launcher 2\Modules\ModSecret.vb") -replace 'Request.Headers("x-api-key") = ""', 'Request.Headers("x-api-key") = "${{ secrets.x_api_key }}"' | Out-File "Plain Craft Launcher 2\Modules\ModSecret.vb"
 
     - name: Build
       run: msbuild "Plain Craft Launcher 2\Plain Craft Launcher 2.vbproj" -p:Configuration=${{ matrix.configuration }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,8 +45,9 @@ jobs:
         x-api-key: ${{ secrets.x_api_key }}
       run: |
         (gc "Plain Craft Launcher 2\Modules\ModSecret.vb") -replace '$client_id',   | Out-File "Plain Craft Launcher 2\Modules\ModSecret.vb"
-        (gc "Plain Craft Launcher 2\Modules\ModSecret.vb") -replace 'Client.Headers("x-api-key") = ""', '"Client.Headers("x-api-key") = ""' | Out-File "Plain Craft Launcher 2\Modules\ModSecret.vb"
+        (gc "Plain Craft Launcher 2\Modules\ModSecret.vb") -replace 'Client.Headers("x-api-key") = ""', '"Client.Headers("x-api-key") = "${{ secrets.x_api_key }}"' | Out-File "Plain Craft Launcher 2\Modules\ModSecret.vb"
         (gc "Plain Craft Launcher 2\Modules\ModSecret.vb") -replace '$client_id',  | Out-File "Plain Craft Launcher 2\Modules\ModSecret.vb"
+
     - name: Build
       run: msbuild "Plain Craft Launcher 2\Plain Craft Launcher 2.vbproj" -p:Configuration=${{ matrix.configuration }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ x86/
 bld/
 [Bb]in/
 [Oo]bj/
+[Oo]utput/
 [Ll]og/
 
 # Visual Studio 2015/2017 cache/options directory

--- a/Plain Craft Launcher 2/Modules/ModSecret.vb
+++ b/Plain Craft Launcher 2/Modules/ModSecret.vb
@@ -104,7 +104,8 @@ Friend Module ModSecret
             Client.Headers("User-Agent") = "PCL2/" & VersionStandardCode
         End If
         Client.Headers("Referer") = "http://" & VersionCode & ".pcl2.server/"
-        '如果你有 CurseForge API Key，请添加到 Headers 中，以恢复对 CurseForge 的访问
+        '如果你有 CurseForge API Key，请添加到下面，以恢复对 CurseForge 的访问
+        Client.Headers("x-api-key") = ""
     End Sub
     ''' <summary>
     ''' 设置 Headers 的 UA、Referer。
@@ -117,7 +118,8 @@ Friend Module ModSecret
             Request.UserAgent = "PCL2/" & VersionStandardCode
         End If
         Request.Referer = "http://" & VersionCode & ".pcl2.server/"
-        '如果你有 CurseForge API Key，请添加到 Headers 中，以恢复对 CurseForge 的访问
+        '如果你有 CurseForge API Key，请添加到下面，以恢复对 CurseForge 的访问
+        Request.Headers("x-api-key") = ""
     End Sub
 
 #End Region

--- a/Plain Craft Launcher 2/Modules/ModSecret.vb
+++ b/Plain Craft Launcher 2/Modules/ModSecret.vb
@@ -104,7 +104,7 @@ Friend Module ModSecret
             Client.Headers("User-Agent") = "PCL2/" & VersionStandardCode
         End If
         Client.Headers("Referer") = "http://" & VersionCode & ".pcl2.server/"
-        '如果你有 CurseForge API Key，请添加到下面，以恢复对 CurseForge 的访问
+        '如果你有 CurseForge API Key，可以添加到下面，以恢复对 CurseForge 的访问
         Client.Headers("x-api-key") = ""
     End Sub
     ''' <summary>
@@ -118,7 +118,7 @@ Friend Module ModSecret
             Request.UserAgent = "PCL2/" & VersionStandardCode
         End If
         Request.Referer = "http://" & VersionCode & ".pcl2.server/"
-        '如果你有 CurseForge API Key，请添加到下面，以恢复对 CurseForge 的访问
+        '如果你有 CurseForge API Key，可以添加到下面，以恢复对 CurseForge 的访问
         Request.Headers("x-api-key") = ""
     End Sub
 


### PR DESCRIPTION
替换需要前往 https://github.com/{你的 GitHub ID}/{你的 PCL2 Repo 的名称}/settings/secrets/actions/new 添加 Secret，分别为 client_id （#3940 微软登录所使用的） 和 x_api_key （CurseForge API 用的 API Key，因为 Secrets 名称符号只能用下划线，才从 x-api-key 改为 x_api_key）。
至于 Output 文件夹，上个 PR 的作者忘加了……我顺便给加下，避免上传测试程序。