### PR TITLE
fix: 检测愚人节版本所用时区不正确

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadClient.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadClient.xaml.vb
@@ -45,7 +45,8 @@
                                 Version.Add("lore", GetMcFoolName(Version("id")))
                         End Select
                         '所有4月1日发布的版本可视为愚人节版，但不改动版本描述
-                        Select Case Version("releaseTime").Value(Of Date).ToString("MM'/'dd")
+                        Dim swedenTime As Date = Version("releaseTime").Value(Of Date).ToUniversalTime().AddHours(2)
+                        Select Case swedenTime.ToString("MM'/'dd")
                             Case "04/01"
                                 If Not Version("type") = "special" Then
                                     Type = "愚人节版"

--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.vb
@@ -620,7 +620,8 @@
                                 Version.Add("lore", GetMcFoolName(Version("id")))
                         End Select
                         '所有4月1日发布的版本视为愚人节版，但不改动版本描述
-                        Select Case Version("releaseTime").Value(Of Date).ToString("MM'/'dd")
+                        Dim swedenTime As Date = Version("releaseTime").Value(Of Date).ToUniversalTime().AddHours(2)
+                        Select Case swedenTime.ToString("MM'/'dd")
                             Case "04/01"
                                 If Not Version("type") = "special" Then
                                     Type = "愚人节版"


### PR DESCRIPTION
main 分支编译的 PCL 显示：
![image](https://github.com/user-attachments/assets/4855b2df-b861-480d-87da-1ac511acd2fa)
而 https://zh.minecraft.wiki/w/21w13a 介绍是在 3月31日发布