### PR TITLE
通过检测波浪号的方式 Fix #4505

### DIFF
--- a/Plain Craft Launcher 2/Modules/Base/ModValidate.vb
+++ b/Plain Craft Launcher 2/Modules/Base/ModValidate.vb
@@ -214,6 +214,7 @@ Public Class ValidateFolderName
         On Error Resume Next
         PathIgnore = New DirectoryInfo(Path).EnumerateDirectories
     End Sub
+
     Public Overrides Function Validate(Str As String) As String
         Try
             '检查是否为空
@@ -233,6 +234,8 @@ Public Class ValidateFolderName
             '检查特殊字符串
             Dim InvalidStrCheck As String = New ValidateExceptSame({"CON", "PRN", "AUX", "CLOCK$", "NUL", "COM0", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "LPT0", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"}, "文件夹名不可为 %！", True).Validate(Str)
             If Not InvalidStrCheck = "" Then Return InvalidStrCheck
+            '检查波浪号 (issue #4505)
+            If Str.Contains("~") Then Return "文件名不能包含波浪号！"
             '检查文件夹重名
             Dim Arr As New List(Of String)
             If PathIgnore IsNot Nothing Then
@@ -286,6 +289,8 @@ Public Class ValidateFileName
             '检查特殊字符串
             Dim InvalidStrCheck As String = New ValidateExceptSame({"CON", "PRN", "AUX", "CLOCK$", "NUL", "COM0", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "LPT0", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"}, "文件名不可为 %！", True).Validate(Str)
             If Not InvalidStrCheck = "" Then Return InvalidStrCheck
+            '检查波浪号 (issue #4505)
+            If Str.Contains("~") Then Return "文件名不能包含波浪号！"
             '检查文件重名
             If ParentFolder IsNot Nothing Then
                 Dim DirInfo As New DirectoryInfo(ParentFolder)
@@ -351,6 +356,8 @@ Fin:
             '检查特殊字符串
             Dim InvalidStrCheck As String = New ValidateExceptSame({"CON", "PRN", "AUX", "CLOCK$", "NUL", "COM0", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "LPT0", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"}, "文件夹名不可为 %！").Validate(SubStr)
             If Not InvalidStrCheck = "" Then Return InvalidStrCheck
+            '检查波浪号 (issue #4505)
+            If Str.Contains("~") Then Return "文件夹名不能包含波浪号！"
         Next
         Return ""
     End Function


### PR DESCRIPTION
因为 Windows 的奇怪机制，导致我没有测试出来其他形式的短文件名是否会导致此问题。
这是我写的一个检测 NTFS 8.3 文件名的方法，因为 Windows 的短文件名规则实在太奇怪没用上去，龙猫可以看看：
```Visual Basic
Public Function IsValidNTFS83Filename(filename As String) As Boolean
    ' 检查是否为空字符串
    If String.IsNullOrEmpty(filename) Then
        Return False
    End If

    ' 分隔文件名和扩展名
    Dim namePart As Byte() = {}
    Dim extPart As Byte() = {}

    Dim dotIndex As Integer = filename.LastIndexOf(".")
    If dotIndex <> -1 AndAlso dotIndex > 0 AndAlso dotIndex < filename.Length - 1 Then
        namePart = Encoding.UTF8.GetBytes(filename.Substring(0, dotIndex))
        extPart = Encoding.UTF8.GetBytes(filename.Substring(dotIndex + 1))
    Else
        namePart = Encoding.UTF8.GetBytes(filename)
    End If

    ' 检查名称部分
    If namePart.Length > 8 Then
        Return False
    End If

    ' 检查扩展名部分
    If extPart.Length = 0 AndAlso extPart.Length > 3 Then
        Return False
    End If

    ' 8.3 文件名要求在文件名部分长度为 1 到 8 字符
    If namePart.Length <> 8 Then
        Return False
    Else
        Dim ignored As Integer
        If Integer.TryParse(namePart(7), ignored) AndAlso extPart.Length = 3 Then
            Return True
        End If
    End If
    Return False
End Function
```