### PR TITLE
修复: 判断语言是否为中文 -> 判断语言是否为中文（中国）

### DIFF
--- a/Plain Craft Launcher 2/Modules/Base/ModBase.vb
+++ b/Plain Craft Launcher 2/Modules/Base/ModBase.vb
@@ -1975,11 +1975,12 @@ RetryDir:
     End Function
 
     ''' <summary>
-    ''' 判断当前系统语言是否为中文。
+    ''' 判断当前系统语言是否为中文（中国）。
     ''' </summary>
     Public Function IsSystemLanguageChinese() As Boolean
-        Return CultureInfo.CurrentCulture.TwoLetterISOLanguageName = "zh" OrElse CultureInfo.CurrentUICulture.TwoLetterISOLanguageName = "zh"
+        Return CultureInfo.CurrentCulture.Name = "zh-CN" OrElse CultureInfo.CurrentUICulture.Name = "zh-CN"
     End Function
+
 
     Private Uuid As Integer = 1
     Private UuidLock As Object


### PR DESCRIPTION
原始 Issue: #5292
对 `PCL2/Plain Craft Launcher 2/Modules/Base/ModBase.vb` 文件中的语言判断进行了修改，使得其不再只是检查系统语系是否为中文而是细分到 `中文（中华人民共和国）`。