### PR TITLE
Fix: 重复发生未处理的错误时，不再强制结束程序

### DIFF
--- a/Plain Craft Launcher 2/Application.xaml.vb
+++ b/Plain Craft Launcher 2/Application.xaml.vb
@@ -158,11 +158,7 @@ WaitRetry:
         On Error Resume Next
         e.Handled = True
         If IsProgramEnded Then Exit Sub
-        If IsCritErrored Then
-            '在汇报错误后继续引发错误，知道这次压不住了
-            FormMain.EndProgramForce(Result.Exception)
-            Exit Sub
-        End If
+        If IsCritErrored Then Exit Sub
         IsCritErrored = True
         Dim ExceptionString As String = GetExceptionDetail(e.Exception, True)
         If ExceptionString.Contains("System.Windows.Threading.Dispatcher.Invoke") OrElse


### PR DESCRIPTION
在汇报错误后，错误重复发生（尤其是同一错误重复发生，#5377）时，不再强制结束 PCL 程序。
*~主页发生错误就直接把 PCL 程序给掐了怪不好的（~*

在发生未处理的错误时，PCL 会弹出一个要求反馈的窗口，而在这个窗口中，无论选择 ”是“ 或者 ”否“，都会强制结束 PCL 程序。因此，这部分代码似乎没有什么实际作用？🤔

