### PR TITLE
“设置/个性化/功能隐藏”字样在PCL2小窗口时不能完整显示文本

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUI.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUI.xaml
@@ -263,7 +263,7 @@
                             <ColumnDefinition Width="0.8*" />
                             <ColumnDefinition Width="0.9*" />
                             <ColumnDefinition Width="0.8*" />
-                            <ColumnDefinition Width="0.6*" />
+                            <ColumnDefinition Width="0.8*" />
                             <ColumnDefinition Width="1.0*" />
                         </Grid.ColumnDefinitions>
                         <Grid.RowDefinitions>


### PR DESCRIPTION
Fixes #5366
![image](https://github.com/user-attachments/assets/76fd5008-dc6f-4156-827d-4d93a397633c)
