### PR TITLE
[可视化mod列表出错...]搜索Sand Filter时必报错

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModComp.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModComp.vb
@@ -434,7 +434,10 @@
         Public Function ToCompItem(ShowMcVersionDesc As Boolean, ShowLoaderDesc As Boolean) As MyCompItem
             '获取版本描述
             Dim GameVersionDescription As String
-            If GameVersions Is Nothing OrElse Not GameVersions.Any() Then
+            Dim AllSnapshot As Boolean = GameVersions.All(Function(v) RegexCheck(v, "[0-9]{2}w[0-9]{2}[a-z]{1}"))
+            If AllSnapshot Then
+                GameVersionDescription = "仅快照版本"
+            ElseIf GameVersions Is Nothing OrElse Not GameVersions.Any() Then
                 GameVersionDescription = "未知"
             Else
                 Dim SpaVersions As New List(Of String)
@@ -493,10 +496,17 @@
                     ModLoaderDescriptionFull = "仅 " & ModLoadersForDesc.Single.ToString
                     ModLoaderDescriptionPart = ModLoadersForDesc.Single.ToString
                 Case Else
-                    If ModLoaders.Contains(CompModLoaderType.Forge) AndAlso
+                    If ModLoaders.Contains(CompModLoaderType.Forge) AndAlso Not AllSnapshot AndAlso
                        (GameVersions.Max < 14 OrElse ModLoaders.Contains(CompModLoaderType.Fabric)) AndAlso
                        (GameVersions.Max < 20 OrElse ModLoaders.Contains(CompModLoaderType.NeoForge)) AndAlso
                        (GameVersions.Max < 14 OrElse ModLoaders.Contains(CompModLoaderType.Quilt) OrElse Setup.Get("ToolDownloadIgnoreQuilt")) Then
+                        ModLoaderDescriptionFull = "任意"
+                        ModLoaderDescriptionPart = ""
+                    ElseIf AllSnapshot AndAlso
+                        ModLoaders.Contains(CompModLoaderType.Forge) AndAlso
+                        ModLoaders.Contains(CompModLoaderType.Fabric) AndAlso
+                        ModLoaders.Contains(CompModLoaderType.NeoForge) AndAlso
+                        (ModLoaders.Contains(CompModLoaderType.Quilt) OrElse Setup.Get("ToolDownloadIgnoreQuilt")) Then
                         ModLoaderDescriptionFull = "任意"
                         ModLoaderDescriptionPart = ""
                     Else


### PR DESCRIPTION
Fixes #5255
Issue 原因：如一个Mod仅支持快照版本及多于一个Mod加载器，搜索结果含有该Mod，代码（显示多于一个Mod加载器）出错，该Mod以及该搜索结果页面的后续所有Mod均不能被展示
![image](https://github.com/user-attachments/assets/93517f34-c6e0-4b63-8cff-cf7eea5948e2)
![image](https://github.com/user-attachments/assets/3b40bb5e-1d92-4b1c-8fa9-35b9cc94b6fd)
![image](https://github.com/user-attachments/assets/67d4f9be-200f-4606-815e-87f717d48d92)
修复：

- [x] 仅支持快照版本现显示为仅快照版本而不是未知
- [x] 更改代码逻辑（显示多于一个Mod加载器）