### PR TITLE
Fix:硬编码路径导致编译问题

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         Set-Location PCL2Help
         Remove-Item -Path *.* -Recurse -Force
         Compress-Archive -Path .\* -DestinationPath .\Help.zip
-        Copy-Item -Path .\Help.zip -Destination "..\PCL2\Plain Craft Launcher 2\Resources\Help.zip" -Force
+        Copy-Item -Path .\Help.zip -Destination $path + "\Plain Craft Launcher 2\Resources\Help.zip" -Force
         Set-Location $path
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,13 +38,13 @@ jobs:
     
     - name: Update Help
       run:  |
-        $wkpath = [System.Environment]::CurrentDirectory
+        $workpath = [System.Environment]::CurrentDirectory
         Set-Location ..
         git clone https://github.com/LTCatt/PCL2Help.git -b master --single-branch --depth 1
         Set-Location PCL2Help
         Remove-Item -Path *.* -Recurse -Force
         Compress-Archive -Path .\* -DestinationPath .\Help.zip
-        Copy-Item -Path .\Help.zip -Destination "$wkpath\Plain Craft Launcher 2\Resources\Help.zip" -Force
+        Copy-Item -Path .\Help.zip -Destination "$workpath\Plain Craft Launcher 2\Resources\Help.zip" -Force
         Set-Location $path
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,13 +38,13 @@ jobs:
     
     - name: Update Help
       run:  |
-        $path = [System.Environment]::CurrentDirectory
+        $wkpath = [System.Environment]::CurrentDirectory
         Set-Location ..
         git clone https://github.com/LTCatt/PCL2Help.git -b master --single-branch --depth 1
         Set-Location PCL2Help
         Remove-Item -Path *.* -Recurse -Force
         Compress-Archive -Path .\* -DestinationPath .\Help.zip
-        Copy-Item -Path .\Help.zip -Destination $path + "\Plain Craft Launcher 2\Resources\Help.zip" -Force
+        Copy-Item -Path .\Help.zip -Destination "$wkpath\Plain Craft Launcher 2\Resources\Help.zip" -Force
         Set-Location $path
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,13 +38,14 @@ jobs:
     
     - name: Update Help
       run:  |
+        $path = [System.Environment]::CurrentDirectory
         Set-Location ..
         git clone https://github.com/LTCatt/PCL2Help.git -b master --single-branch --depth 1
         Set-Location PCL2Help
         Remove-Item -Path *.* -Recurse -Force
         Compress-Archive -Path .\* -DestinationPath .\Help.zip
         Copy-Item -Path .\Help.zip -Destination "..\PCL2\Plain Craft Launcher 2\Resources\Help.zip" -Force
-        Set-Location ..\PCL2
+        Set-Location $path
 
 
     - name: Replace


### PR DESCRIPTION
使用 .NET 程序集 System.Environment 的 CurrentDirectory 获取工作目录代替硬编码目录导致编译问题

考虑不周了，抱歉