### PR TITLE
fix #5766: 通过FormMain#PageChange调用（例如自定义主页按钮的切换页面EventType）调出反馈/投票弹窗时会导致异常及RadioButton的不正确选中

### DIFF
--- a/Plain Craft Launcher 2/FormMain.xaml.vb
+++ b/Plain Craft Launcher 2/FormMain.xaml.vb
@@ -896,6 +896,8 @@ Public Class FormMain
         OtherHelp = 0
         OtherAbout = 1
         OtherTest = 2
+        OtherFeedback = 3
+        OtherVote = 4
         VersionOverall = 0
         VersionSetup = 1
         VersionMod = 2
@@ -1023,11 +1025,8 @@ Public Class FormMain
     ''' </summary>
     Public Sub PageChange(Stack As PageStackData, Optional SubType As PageSubType = PageSubType.Default)
         If PageNameGet(Stack) = "" Then
-            '切换到主页面
-            PageChangeExit()
-            IsChangingPage = True '防止下面的勾选直接触发了 PageChangeActual
-            CType(PanTitleSelect.Children(Stack), MyRadioButton).SetChecked(True, True, PageNameGet(PageCurrent) = "")
-            IsChangingPage = False
+            '在Select块中判断是否应该执行切换回主页面并修改正在选中的RadioButton的逻辑
+            Dim ShouldChangePage As Boolean = True
             Select Case Stack.Page
                 Case PageType.Download
                     If FrmDownloadLeft Is Nothing Then FrmDownloadLeft = New PageDownloadLeft
@@ -1036,10 +1035,23 @@ Public Class FormMain
                     If FrmSetupLeft Is Nothing Then FrmSetupLeft = New PageSetupLeft
                     CType(FrmSetupLeft.PanItem.Children(SubType), MyListItem).SetChecked(True, True, Stack = PageCurrent)
                 Case PageType.Other
-                    If FrmOtherLeft Is Nothing Then FrmOtherLeft = New PageOtherLeft
-                    CType(FrmOtherLeft.PanItem.Children(SubType), MyListItem).SetChecked(True, True, Stack = PageCurrent)
+                    '当是反馈/投票时子页面只是一个弹窗，此时不应该切换页面 (#5766)
+                    If PageOtherLeft.IsSubPageMsgBox(SubType) Then
+                        ShouldChangePage = False
+                        PageOtherLeft.OpenMsgSubPage(SubType)
+                    Else
+                        If FrmOtherLeft Is Nothing Then FrmOtherLeft = New PageOtherLeft
+                        CType(FrmOtherLeft.PanItem.Children(SubType), MyListItem).SetChecked(True, True, Stack = PageCurrent)
+                    End If
             End Select
-            PageChangeActual(Stack, SubType)
+            If ShouldChangePage Then
+                '切换到主页面
+                PageChangeExit()
+                IsChangingPage = True '防止下面的勾选直接触发了 PageChangeActual
+                CType(PanTitleSelect.Children(Stack), MyRadioButton).SetChecked(True, True, PageNameGet(PageCurrent) = "")
+                IsChangingPage = False
+                PageChangeActual(Stack, SubType)
+            End If
         Else
             '切换到次页面
             Select Case Stack.Page

--- a/Plain Craft Launcher 2/Pages/PageOther/PageOtherLeft.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageOther/PageOtherLeft.xaml.vb
@@ -55,6 +55,28 @@
         If sender.Tag IsNot Nothing Then PageChange(Val(sender.Tag))
     End Sub
 
+    ''' <returns>
+    ''' True - 当传入的值对应的子页面仅为一个MsgBox
+    ''' </returns>
+    Public Shared Function IsSubPageMsgBox(Optional ID As FormMain.PageSubType = -1) As Boolean
+        If ID = FormMain.PageSubType.OtherFeedback OrElse ID = FormMain.PageSubType.OtherVote Then
+            Return True
+        Else
+            Return False
+        End If
+    End Function
+
+    Public Shared Sub OpenMsgSubPage(ID As FormMain.PageSubType)
+        Select Case ID
+            Case FormMain.PageSubType.OtherFeedback
+                TryFeedback()
+            Case FormMain.PageSubType.OtherVote
+                TryVote()
+            Case Else
+                Throw New Exception("未知的更多子页面种类（消息框）：" & ID)
+        End Select
+    End Sub
+
     Public Function PageGet(Optional ID As FormMain.PageSubType = -1)
         If ID = -1 Then ID = PageID
         Select Case ID


### PR DESCRIPTION
涉及的原有行为更改：在`FormMain.xaml.vb#PageChange`中将切换为主页面以及更改选中的`RadioButton`的逻辑（如下）挪到了`Select`块（创建将要打开的主页面以及选中将要打开的子页面）之后以允许判断。
```vb.net
PageChangeExit()
IsChangingPage = True '防止下面的勾选直接触发了 PageChangeActual
CType(PanTitleSelect.Children(Stack), MyRadioButton).SetChecked(True, True, PageNameGet(PageCurrent) = "")
IsChangingPage = False
```
