### PR TITLE
Refactor：重构下载管理页面

### DIFF
--- a/Plain Craft Launcher 2/Application.xaml
+++ b/Plain Craft Launcher 2/Application.xaml
@@ -19,6 +19,7 @@
             <local:MultiplicationConverter x:Key="MultiplicationConverter"/>
             <local:InverseBooleanToVisibilityConverter x:Key="InverseBooleanToVisibilityConverter"/>
             <local:InverseBooleanConverter x:Key="InverseBooleanConverter"/>
+            <local:DlStateConveter x:Key="DlStateConverter" />
 
             <!-- 颜色表 -->
             <SolidColorBrush x:Key="ColorBrush1">#343d4a</SolidColorBrush>

--- a/Plain Craft Launcher 2/Controls/MyDlEntry.xaml
+++ b/Plain Craft Launcher 2/Controls/MyDlEntry.xaml
@@ -1,0 +1,25 @@
+﻿<local:MyCard x:Class="MyDlEntry"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:PCL">
+    <local:MyIconButton x:Name="BtnCancel" Logo="F1 M2,0 L0,2 8,10 0,18 2,20 10,12 18,20 20,18 12,10 20,2 18,0 10,8 2,0Z"
+                        Height="20" Margin="0 10 10 0" LogoScale="1.1" HorizontalAlignment="Right" VerticalAlignment="Top" />
+    <ListBox x:Name="TaskListBox" ItemsSource="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:MyDlEntry}, Path=TaskEntries}"
+                 Background="Transparent" BorderThickness="0" IsHitTestVisible="False" Margin="14 40 15 10">
+        <ListBox.ItemTemplate>
+            <DataTemplate>
+                <Grid MinHeight="26">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="50" />
+                        <ColumnDefinition />
+                    </Grid.ColumnDefinitions>
+                    <ContentPresenter Grid.Column="0" Content="{Binding LoaderState, Converter={StaticResource DlStateConverter}}" />
+                    <TextBlock Grid.Column="1" Text="{Binding Descreption, Mode=OneWay}" TextWrapping="Wrap" HorizontalAlignment="Left" VerticalAlignment="Top" />
+                </Grid>
+            </DataTemplate>
+        </ListBox.ItemTemplate>
+    </ListBox>
+    <local:MyHint x:Name="ExceptionHint" Visibility="Collapsed" ToolTip="单击复制错误详情" Margin="14 40 15 10" />
+</local:MyCard>

--- a/Plain Craft Launcher 2/Controls/MyDlEntry.xaml.vb
+++ b/Plain Craft Launcher 2/Controls/MyDlEntry.xaml.vb
@@ -1,0 +1,146 @@
+﻿Imports System.Collections.ObjectModel
+Imports System.ComponentModel
+
+Public Class MyDlEntry
+    Inherits MyCard
+
+    ''' <summary>
+    ''' 卡片中每一条子下载任务的数据模型，将Loader作为唯一标识符
+    ''' </summary>
+    Public Class MyDlTaskEntry
+        Implements INotifyPropertyChanged
+
+        Public Event PropertyChanged As PropertyChangedEventHandler Implements INotifyPropertyChanged.PropertyChanged
+
+        Public Sub New(Loader As LoaderBase)
+            Me.Loader = Loader
+            _LoaderState = Loader.State
+            _Progress = Loader.Progress
+            _Descreption = Loader.Name
+        End Sub
+
+        ''' <summary>
+        ''' 检查值有无改变以及通知前端
+        ''' </summary>
+        Public Sub SyncValuesToUI()
+            If (Not Loader.State = _LoaderState) Then
+                _LoaderState = Loader.State
+                RaiseEvent PropertyChanged(Me, New PropertyChangedEventArgs("LoaderState"))
+            End If
+            If (Not Loader.Progress = _Progress) Then
+                _Progress = Loader.Progress
+                RaiseEvent PropertyChanged(Me, New PropertyChangedEventArgs("PercentStr"))
+            End If
+        End Sub
+
+        Public Loader As LoaderBase
+
+        Private _LoaderState As LoadState
+        Public ReadOnly Property LoaderState As LoadState
+            Get
+                Return _LoaderState
+            End Get
+        End Property
+
+        Private _Progress As Double
+        Public ReadOnly Property PercentStr As String
+            Get
+                Return Math.Floor(_Progress * 100) & "%"
+            End Get
+        End Property
+
+        Private _Descreption As String
+        Public ReadOnly Property Descreption As String
+            Get
+                Return _Descreption
+            End Get
+        End Property
+    End Class
+
+    ''' <summary>
+    ''' TaskListBox的数据源
+    ''' </summary>
+    Public ReadOnly Property TaskEntries As New ObservableCollection(Of MyDlTaskEntry)
+
+    Public Loader As LoaderBase
+
+    ''' <summary>
+    ''' 获取所有子下载任务
+    ''' </summary>
+    Private ReadOnly Property SubDlTasks As List(Of LoaderBase)
+        Get
+            Return CType(Loader, Object).GetLoaderList()
+        End Get
+    End Property
+
+    Private _Failed As Boolean
+    ''' <summary>
+    ''' 是否已经失败，值发生改变时切换显示内容
+    ''' </summary>
+    Private Property Failed
+        Get
+            Return _Failed
+        End Get
+        Set(value)
+            If value = _Failed Then Exit Property
+            _Failed = value
+            If value Then
+                ExceptionHint.Text = GetExceptionDetail(Loader.Error)
+                ExceptionHint.Visibility = Visibility.Visible
+                TaskListBox.Visibility = Visibility.Collapsed
+            Else '应该不会进到这个case里
+                ExceptionHint.Visibility = Visibility.Collapsed
+                TaskListBox.Visibility = Visibility.Visible
+            End If
+        End Set
+    End Property
+
+    Public Sub New(Loader As LoaderBase)
+        InitializeComponent()
+        Me.Loader = Loader
+        Title = Loader.Name
+        RefreshSubTasks()
+    End Sub
+
+    ''' <summary>
+    ''' 同步前端状态（是否已失败、初次调用时添加子任务显示条目、刷新子任务显示条目的信息）
+    ''' </summary>
+    Public Sub RefreshSubTasks()
+        If Failed Then Exit Sub
+        Try
+            If Loader.State = LoadState.Failed Then
+                Failed = True
+            Else
+                For Each DlTask As LoaderBase In SubDlTasks
+                    Dim TaskEntry = TaskEntries.FirstOrDefault(Function(t) t.Loader Is DlTask)
+                    If TaskEntry Is Nothing Then '除了第一次调用之外不会进入这个case，因为LoaderCombo的子加载任务不会增加
+                        TaskEntries.Add(New MyDlTaskEntry(DlTask))
+                    Else
+                        TaskEntry.SyncValuesToUI()
+                    End If
+                Next
+            End If
+        Catch ex As Exception
+            Log(ex, "刷新下载管理显示失败", LogLevel.Feedback)
+        End Try
+    End Sub
+
+    ''' <summary>
+    ''' 点击失败提示卡片之后复制错误信息到剪贴板
+    ''' </summary>
+    Private Sub CopyExceptionDetail(sender As MyHint, e As EventArgs) Handles ExceptionHint.MouseLeftButtonDown
+        ClipboardSet(sender.Text, False)
+        Hint("已复制错误详情！", HintType.Finish)
+    End Sub
+
+    ''' <summary>
+    ''' 点击取消按钮之后播放关闭动画、中止Loader
+    ''' </summary>
+    Private Sub Cancel(sender As MyIconButton, e As EventArgs) Handles BtnCancel.Click
+        AniDispose(sender, False)
+        AniDispose(Me, True, Sub() FrmSpeedRight?.TryReturnToHome())
+        RunInThread(Sub() Loader.Abort())
+        LoaderTaskbar.Remove(Loader)
+    End Sub
+
+End Class

--- a/Plain Craft Launcher 2/Modules/Base/ModBase.vb
+++ b/Plain Craft Launcher 2/Modules/Base/ModBase.vb
@@ -3031,4 +3031,27 @@ Public Class InverseBooleanConverter
     End Function
 End Class
 
+''' <summary>
+''' 在MyDlEntry中使用，将LoaderState转换为一个UI元素；未实现反向转换。
+''' </summary>
+Public Class DlStateConveter
+    Implements IValueConverter
+    Public Function Convert(value As Object, targetType As Type, parameter As Object, culture As CultureInfo) As Object Implements IValueConverter.Convert
+        If value Is Nothing OrElse TypeOf value IsNot LoadState Then Return Nothing
+        Select Case value
+            Case LoadState.Waiting
+                Return GetObjectFromXML("<Path xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation"" Stretch=""Uniform"" Tag=""Waiting"" Data=""F1 M5,0 a5,5 360 1 0 0,0.0001 m15,0 a5,5 360 1 0 0,0.0001 m15,0 a5,5 360 1 0 0,0.0001 Z"" Width=""18"" HorizontalAlignment=""Center"" Fill=""{DynamicResource ColorBrush3}"" Margin=""0,7,0,0"" VerticalAlignment=""Top"" Height=""6""/>")
+            Case LoadState.Loading
+                Return GetObjectFromXML("<TextBlock xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation"" Text=""{Binding PercentStr, Mode=OneWay}"" Tag=""Loading"" HorizontalAlignment=""Center"" Foreground=""{DynamicResource ColorBrush3}"" />")
+            Case LoadState.Finished
+                Return GetObjectFromXML("<Path xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation"" Stretch=""Uniform"" Tag=""Finished"" Data=""F1 M 23.7501,33.25L 34.8334,44.3333L 52.2499,22.1668L 56.9999,26.9168L 34.8334,53.8333L 19.0001,38L 23.7501,33.25 Z"" Height=""16"" Width=""15"" HorizontalAlignment=""Center"" Fill=""{DynamicResource ColorBrush3}"" Margin=""0,3,0,0"" VerticalAlignment=""Top""/>")
+            Case Else 'Failed, Aborted
+                Return GetObjectFromXML("<Path xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation"" Stretch=""Uniform"" Tag=""Failed"" Data=""F1 M2.5,0 L0,2.5 7.5,10 0,17.5 2.5,20 10,12.5 17.5,20 20,17.5 12.5,10 20,2.5 17.5,0 10,7.5 2.5,0Z"" Height=""15"" Width=""15"" HorizontalAlignment=""Center"" Fill=""{DynamicResource ColorBrush3}"" Margin=""0,1,0,0"" VerticalAlignment=""Top""/>")
+        End Select
+    End Function
+    Public Function ConvertBack(value As Object, targetType As Type, parameter As Object, culture As CultureInfo) As Object Implements IValueConverter.ConvertBack
+        Return LoadState.Waiting
+    End Function
+End Class
+
 #End Region

--- a/Plain Craft Launcher 2/Modules/Base/ModLoader.vb
+++ b/Plain Craft Launcher 2/Modules/Base/ModLoader.vb
@@ -576,7 +576,7 @@ Restart:
     Private LoaderTaskbarProgressLast As Shell.TaskbarItemProgressState = Shell.TaskbarItemProgressState.None
 
     Public Sub LoaderTaskbarAdd(Of T)(Loader As LoaderCombo(Of T))
-        If FrmSpeedLeft IsNot Nothing Then FrmSpeedLeft.TaskRemove(Loader)
+        If FrmSpeedRight IsNot Nothing Then FrmSpeedRight.TaskRemove(Loader)
         LoaderTaskbar.Add(Loader)
         Log($"[Taskbar] {Loader.Name} 已加入任务列表")
     End Sub
@@ -593,7 +593,7 @@ Restart:
             '若单个任务已中止或全部任务已完成，则刷新并移除
             For Each Task In LoaderTaskbar.ToList()
                 If IsAllDownloadTaskCompleted OrElse Task.State = LoadState.Aborted OrElse Task.State = LoadState.Waiting Then
-                    If FrmSpeedLeft IsNot Nothing Then FrmSpeedLeft.TaskRefresh(Task)
+                    If FrmSpeedRight IsNot Nothing Then FrmSpeedRight.TaskRefresh(Task)
                     LoaderTaskbar.Remove(Task)
                     Log($"[Taskbar] {Task.Name} 已移出任务列表")
                 End If

--- a/Plain Craft Launcher 2/Pages/PageSpeedLeft.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageSpeedLeft.xaml.vb
@@ -10,15 +10,18 @@ Public Class PageSpeedLeft
         '进入时就刷新一次显示
         Watcher()
 
-        '如果在页面切换动画的 “上一页消失” 部分已经完成了下载，就直接尝试返回
-        TryReturnToHome()
-
         If IsLoad Then Exit Sub
         IsLoad = True
 
         '监控定时器
         Dim timer As New Threading.DispatcherTimer With {.Interval = New TimeSpan(0, 0, 0, 0, WatcherInterval)}
-        AddHandler timer.Tick, AddressOf Watcher
+        AddHandler timer.Tick,
+            Sub()
+                If FrmMain.PageCurrent = FormMain.PageType.DownloadManager Then
+                    Watcher()
+                    FrmSpeedRight?.Watcher()
+                End If
+            End Sub
         timer.Start()
 
         '非调试模式隐藏线程数
@@ -58,179 +61,6 @@ Public Class PageSpeedLeft
         Catch ex As Exception
             Log(ex, "下载管理左栏监视出错", LogLevel.Feedback)
         End Try
-        If FrmSpeedRight Is Nothing OrElse FrmSpeedRight.PanMain Is Nothing Then Exit Sub
-        Try
-            For Each Loader In LoaderTaskbar.ToList
-                TaskRefresh(Loader)
-            Next
-        Catch ex As Exception
-            Log(ex, "下载管理右栏监视出错", LogLevel.Feedback)
-        End Try
-    End Sub
-    Public Sub TaskRefresh(Loader As LoaderBase)
-        If Loader Is Nothing OrElse Not Loader.Show Then Exit Sub
-        Try
-            '获取实际加载器列表
-            Dim LoaderList As List(Of LoaderBase) = CType(Loader, Object).GetLoaderList()
-            If RightCards.ContainsKey(Loader.Name) Then
-                '已有此卡片
-                Dim Card As Grid = RightCards(Loader.Name)
-                Dim NewValue As Double = Loader.Progress + Loader.State
-                If Val(Card.Tag) = NewValue Then Exit Sub
-                Card.Tag = NewValue
-                If Card.Children.Count <= 3 Then
-                    Log("[Watcher] 元素不足的卡片：" & Loader.Name, LogLevel.Debug)
-                    Exit Sub
-                End If
-                Card = Card.Children(3)
-                Try
-                    Select Case Loader.State
-                        Case LoadState.Failed
-#Region "失败，更新卡片"
-                            Card.RowDefinitions.Clear()
-                            Card.Children.Clear()
-                            Card.Children.Add(GetObjectFromXML("<Path xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation"" Stretch=""Uniform"" Tag=""Failed"" Data=""F1 M2.5,0 L0,2.5 7.5,10 0,17.5 2.5,20 10,12.5 17.5,20 20,17.5 12.5,10 20,2.5 17.5,0 10,7.5 2.5,0Z"" Height=""15"" Width=""15"" HorizontalAlignment=""Center"" Grid.Column=""0"" Grid.Row=""0"" Fill=""{DynamicResource ColorBrush3}"" Margin=""0,1,0,0"" VerticalAlignment=""Top""/>"))
-                            Dim Tb As TextBlock = GetObjectFromXML("<TextBlock xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation"" TextWrapping=""Wrap"" HorizontalAlignment=""Left"" ToolTip=""单击复制错误详情"" Grid.Column=""1"" Grid.Row=""0"" Margin=""0,0,0,5"" />")
-                            Tb.Text = GetExceptionDetail(Loader.Error)
-                            AddHandler Tb.MouseLeftButtonDown,
-                            Sub(sender As TextBlock, e As EventArgs)
-                                ClipboardSet(sender.Text, False)
-                                Hint("已复制错误详情！", HintType.Finish)
-                            End Sub
-                            Card.Children.Add(Tb)
-#End Region
-                        Case LoadState.Finished
-#Region "完成，销毁卡片并返回"
-                            AniDispose(CType(Card.Parent, MyCard), True, AddressOf TryReturnToHome)
-#End Region
-                        Case LoadState.Loading, LoadState.Waiting
-#Region "进度不同，更新卡片"
-                            Try
-                                If Card.Children.Count < LoaderList.Count * 2 Then
-                                    Log($"[Watcher] 刷新下载管理卡片 {Loader.Name} 失败：卡片中仅有 {Card.Children.Count} 个子项，要求至少有 {LoaderList.Count * 2} 个子项", LogLevel.Debug)
-                                    Exit Try
-                                End If
-                                Dim Row As Integer = 0
-                                For Each SubTask In LoaderList
-                                    Select Case SubTask.State
-                                        Case LoadState.Waiting
-                                            If CType(Card.Children(Row * 2), FrameworkElement).Tag <> "Waiting" Then
-                                                Card.Children.RemoveAt(Row * 2)
-                                                Card.Children.Insert(Row * 2, GetObjectFromXML("<Path xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation"" xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"" xmlns:local=""clr-namespace:PCL;assembly=Plain Craft Launcher 2"" Stretch=""Uniform"" Tag=""Waiting"" Data=""F1 M5,0 a5,5 360 1 0 0,0.0001 m15,0 a5,5 360 1 0 0,0.0001 m15,0 a5,5 360 1 0 0,0.0001 Z"" Width=""18"" HorizontalAlignment=""Center"" Grid.Column=""0"" Grid.Row=""" & Row & """ Fill=""{DynamicResource ColorBrush3}"" Margin=""0,7,0,0"" VerticalAlignment=""Top"" Height=""6""/>"))
-                                            End If
-                                        Case LoadState.Loading
-                                            If CType(Card.Children(Row * 2), FrameworkElement).Tag <> "Loading" Then
-                                                Card.Children.RemoveAt(Row * 2)
-                                                Card.Children.Insert(Row * 2, GetObjectFromXML("<TextBlock xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation"" xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"" xmlns:local=""clr-namespace:PCL;assembly=Plain Craft Launcher 2"" Text=""" & Math.Floor(SubTask.Progress * 100) & "%"" Tag=""Loading"" HorizontalAlignment=""Center"" Grid.Column=""0"" Grid.Row=""" & Row & """ Foreground=""{DynamicResource ColorBrush3}""/>"))
-                                            Else
-                                                CType(Card.Children(Row * 2), TextBlock).Text = Math.Floor(SubTask.Progress * 100) & "%"
-                                            End If
-                                        Case LoadState.Finished
-                                            If CType(Card.Children(Row * 2), FrameworkElement).Tag <> "Finished" Then
-                                                Card.Children.RemoveAt(Row * 2)
-                                                Card.Children.Insert(Row * 2, GetObjectFromXML("<Path xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation"" xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"" xmlns:local=""clr-namespace:PCL;assembly=Plain Craft Launcher 2"" Stretch=""Uniform"" Tag=""Finished"" Data=""F1 M 23.7501,33.25L 34.8334,44.3333L 52.2499,22.1668L 56.9999,26.9168L 34.8334,53.8333L 19.0001,38L 23.7501,33.25 Z"" Height=""16"" Width=""15"" HorizontalAlignment=""Center"" Grid.Column=""0"" Grid.Row=""" & Row & """ Fill=""{DynamicResource ColorBrush3}"" Margin=""0,3,0,0"" VerticalAlignment=""Top""/>"))
-                                            End If
-                                    End Select
-                                    Row += 1
-                                Next
-                            Catch ex As Exception
-                                Log(ex, $"刷新下载管理卡片 {Loader.Name} 失败", LogLevel.Feedback)
-                            End Try
-#End Region
-                    End Select
-                Catch ex As Exception
-                    Log(ex, "更新下载管理显示失败（" & Loader.State.ToString & "）", LogLevel.Feedback)
-                End Try
-            ElseIf Not (Loader.State = LoadState.Aborted OrElse Loader.State = LoadState.Finished) Then
-                Try
-#Region "没有卡片且未中断或完成，添加新的卡片"
-                    Dim CardXAML As String = "
-                        <local:MyCard xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation"" xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"" xmlns:local=""clr-namespace:PCL;assembly=Plain Craft Launcher 2""
-                            Tag=""" & (Loader.Progress + Loader.State) & """ Title=""" & EscapeXML(Loader.Name) & """ Margin=""0,0,0,15"">
-                            <Grid Margin=""14,40,15,10"">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width=""50""/>
-                                    <ColumnDefinition/>
-                                </Grid.ColumnDefinitions>
-                                <Grid.RowDefinitions>"
-                    For Each SubTask In LoaderList
-                        CardXAML += "<RowDefinition Height=""26""/>"
-                    Next
-                    CardXAML += "</Grid.RowDefinitions>"
-                    Dim Row As Integer = 0
-                    For Each SubTask In LoaderList
-                        Select Case SubTask.State
-                            Case LoadState.Waiting
-                                CardXAML += "<Path Stretch=""Uniform"" Tag=""Waiting"" Data=""F1 M5,0 a5,5 360 1 0 0,0.0001 m15,0 a5,5 360 1 0 0,0.0001 m15,0 a5,5 360 1 0 0,0.0001 Z"" Width=""18"" HorizontalAlignment=""Center"" Grid.Column=""0"" Grid.Row=""" & Row & """ Fill=""{DynamicResource ColorBrush3}"" Margin=""0,7,0,0"" VerticalAlignment=""Top"" Height=""6""/>"
-                            Case LoadState.Loading
-                                CardXAML += "<TextBlock Text=""" & Math.Floor(SubTask.Progress * 100) & "%"" Tag=""Loading"" HorizontalAlignment=""Center"" Grid.Column=""0"" Grid.Row=""" & Row & """ Foreground=""{DynamicResource ColorBrush3}"" />"
-                            Case LoadState.Finished
-                                CardXAML += "<Path Stretch=""Uniform"" Tag=""Finished"" Data=""F1 M 23.7501,33.25L 34.8334,44.3333L 52.2499,22.1668L 56.9999,26.9168L 34.8334,53.8333L 19.0001,38L 23.7501,33.25 Z"" Height=""16"" Width=""15"" HorizontalAlignment=""Center"" Grid.Column=""0"" Grid.Row=""" & Row & """ Fill=""{DynamicResource ColorBrush3}"" Margin=""0,3,0,0"" VerticalAlignment=""Top""/>"
-                            Case Else
-                                CardXAML += "<Path Stretch=""Uniform"" Tag=""Failed"" Data=""F1 M2.5,0 L0,2.5 7.5,10 0,17.5 2.5,20 10,12.5 17.5,20 20,17.5 12.5,10 20,2.5 17.5,0 10,7.5 2.5,0Z"" Height=""15"" Width=""15"" HorizontalAlignment=""Center"" Grid.Column=""0"" Grid.Row=""" & Row & """ Fill=""{DynamicResource ColorBrush3}"" Margin=""0,1,0,0"" VerticalAlignment=""Top""/>"
-                        End Select
-                        CardXAML += "<TextBlock Text=""" & EscapeXML(SubTask.Name) & """ HorizontalAlignment=""Left"" Grid.Column=""1"" Grid.Row=""" & Row & """/>"
-                        Row += 1
-                    Next
-                    CardXAML += "</Grid></local:MyCard>"
-                    '实例化控件
-                    Dim Card As MyCard
-                    Try
-                        Card = GetObjectFromXML(CardXAML)
-                    Catch ex As Exception
-                        Log(ex, "新建下载管理卡片失败")
-                        Log("出错的卡片内容：" & vbCrLf & CardXAML)
-                        Throw
-                    End Try
-                    FrmSpeedRight.PanMain.Children.Insert(0, Card)
-                    RightCards.Add(Loader.Name, Card)
-                    Log($"[Watcher] 新建下载管理卡片：{Loader.Name}")
-                    '添加取消按钮
-                    Dim Cancel As New MyIconButton With {.Name = "BtnCancel", .Logo = "F1 M2,0 L0,2 8,10 0,18 2,20 10,12 18,20 20,18 12,10 20,2 18,0 10,8 2,0Z", .Height = 20, .Margin = New Thickness(0, 10, 10, 0), .LogoScale = 1.1, .HorizontalAlignment = HorizontalAlignment.Right, .VerticalAlignment = VerticalAlignment.Top}
-                    Card.Children.Add(Cancel)
-                    AddHandler Cancel.Click,
-                    Sub(sender As MyIconButton, e As EventArgs)
-                        AniDispose(sender, False)
-                        AniDispose(Card, True, Sub() If FrmSpeedRight.PanMain.Children.Count = 0 AndAlso FrmMain.PageCurrent = FormMain.PageType.DownloadManager Then FrmMain.PageBack())
-                        RightCards.Remove(Loader.Name)
-                        LoaderTaskbar.Remove(Loader)
-                        Log($"[Taskbar] 关闭下载管理卡片：{Loader.Name}，且移出任务列表")
-                        RunInThread(Sub() Loader.Abort())
-                    End Sub
-                    '如果已经失败，再刷新一次，修改成失败的控件
-                    If Loader.State = LoadState.Failed Then
-                        Card.Tag = Nothing '避免重复导致刷新无效
-                        TaskRefresh(Loader)
-                    End If
-#End Region
-                Catch ex As Exception
-                    Log(ex, "添加下载管理卡片失败", LogLevel.Feedback)
-                End Try
-            End If
-        Catch ex As Exception
-            Log(ex, "刷新下载管理显示失败", LogLevel.Feedback)
-        End Try
-    End Sub
-    Public Sub TaskRemove(Loader As Object)
-        If RightCards.ContainsKey(Loader.Name) Then
-            RunInUiWait(
-            Sub()
-                '移除已有的卡片
-                Dim Card As Grid = RightCards(Loader.Name)
-                FrmSpeedRight.PanMain.Children.Remove(Card)
-                RightCards.Remove(Loader.Name)
-                Log($"[Watcher] 移除下载管理卡片：{Loader.Name}")
-            End Sub)
-        End If
-    End Sub
-
-    ''' <summary>
-    ''' 若没有任务，尝试返回主页。
-    ''' </summary>
-    Private Sub TryReturnToHome()
-        If FrmSpeedRight.PanMain.Children.Count = 0 AndAlso FrmMain.PageCurrent = FormMain.PageType.DownloadManager Then
-            FrmMain.PageBack()
-        End If
     End Sub
 
 End Class

--- a/Plain Craft Launcher 2/Pages/PageSpeedRight.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageSpeedRight.xaml.vb
@@ -1,7 +1,75 @@
 ﻿Class PageSpeedRight
 
-    Private Sub Init() Handles Me.Loaded
+    Private Sub Page_Loaded() Handles Me.Loaded
+        '进入时就刷新一次显示
+        Watcher()
+        '如果在页面切换动画的 “上一页消失” 部分已经完成了下载，就直接尝试返回
+        TryReturnToHome()
+
         PanBack.ScrollToHome()
+    End Sub
+
+    '由左侧页面调用
+    Public Sub Watcher()
+        Try
+            For Each Loader As LoaderBase In LoaderTaskbar.ToList
+                TaskRefresh(Loader)
+            Next
+        Catch ex As Exception
+            Log(ex, "下载管理右栏监视出错", LogLevel.Feedback)
+        End Try
+    End Sub
+
+    ''' <summary>
+    ''' 寻找对应这个Loader的下载卡片，找不到返回Nothing
+    ''' </summary>
+    Private Function FindDlCard(Loader As LoaderBase) As MyDlEntry
+        For Each Card In PanMain.Children
+            If TypeOf Card Is MyDlEntry AndAlso CType(Card, MyDlEntry).Loader Is Loader Then Return Card
+        Next
+        Return Nothing
+    End Function
+
+    ''' <summary>
+    ''' 刷新对应这个Loader的下载卡片
+    ''' </summary>
+    Public Sub TaskRefresh(Loader As LoaderBase)
+        If Loader Is Nothing OrElse Not Loader.Show Then Exit Sub
+        Dim DlCard As MyDlEntry = FindDlCard(Loader)
+        Select Case Loader.State
+            Case LoadState.Failed, LoadState.Loading, LoadState.Waiting
+                If DlCard IsNot Nothing Then
+                    DlCard.RefreshSubTasks()
+                Else
+                    PanMain.Children.Add(New MyDlEntry(Loader) With {.Margin = New Thickness(0, 0, 0, 15)})
+                End If
+            Case LoadState.Finished
+                If DlCard IsNot Nothing Then
+                    AniDispose(DlCard, True, AddressOf TryReturnToHome)
+                End If
+        End Select
+    End Sub
+
+    ''' <summary>
+    ''' 删除对应这个Loader的下载卡片
+    ''' </summary>
+    Public Sub TaskRemove(Loader As Object)
+        RunInUiWait(
+            Sub()
+                For Each Card In PanMain.Children
+                    If TypeOf Card IsNot MyDlEntry OrElse CType(Card, MyDlEntry).Loader IsNot Loader Then Continue For
+                    PanMain.Children.Remove(Card)
+                Next
+            End Sub)
+    End Sub
+
+    ''' <summary>
+    ''' 若没有任务，返回主页
+    ''' </summary>
+    Public Sub TryReturnToHome()
+        If FrmSpeedRight.PanMain.Children.Count = 0 AndAlso FrmMain.PageCurrent = FormMain.PageType.DownloadManager Then
+            FrmMain.PageBack()
+        End If
     End Sub
 
 End Class

--- a/Plain Craft Launcher 2/Plain Craft Launcher 2.vbproj
+++ b/Plain Craft Launcher 2/Plain Craft Launcher 2.vbproj
@@ -186,6 +186,9 @@
     <Compile Include="Controls\MyComboBox.vb" />
     <Compile Include="Controls\MyComboBoxItem.vb" />
     <Compile Include="Controls\MyCard.vb" />
+    <Compile Include="Controls\MyDlEntry.xaml.vb">
+      <DependentUpon>MyDlEntry.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Controls\MyExtraTextButton.xaml.vb">
       <DependentUpon>MyExtraTextButton.xaml</DependentUpon>
     </Compile>
@@ -195,9 +198,6 @@
     <Compile Include="Controls\MyIconTextButton.xaml.vb">
       <DependentUpon>MyIconTextButton.xaml</DependentUpon>
     </Compile>
-
-
-
     <Compile Include="Modules\Minecraft\ModComp.vb" />
     <Compile Include="Modules\Minecraft\ModJava.vb" />
     <Compile Include="Modules\Minecraft\ModMod.vb" />
@@ -388,6 +388,10 @@
     <Compile Include="Pages\PageSpeedRight.xaml.vb">
       <DependentUpon>PageSpeedRight.xaml</DependentUpon>
     </Compile>
+    <Page Include="Controls\MyDlEntry.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Controls\MyExtraTextButton.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -489,7 +493,6 @@
       <DependentUpon>FormMain.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
-
     <Page Include="Modules\Minecraft\MyLocalModItem.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -928,7 +931,6 @@
     <Resource Include="Images\Heads\MCBBS.png" />
   </ItemGroup>
   <ItemGroup>
-
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Images\Blocks\NeoForge.png" />


### PR DESCRIPTION
~~千年老史~~
重写右侧页面刷新相关操作并把它们挪到右侧页面的vb文件里
使用 LoaderCombo / LoaderTask 作为唯一标识符 Fixes #4556
对 UI 设计的修改：把下载任务失败后的错误提示从 TextBlock 改成了 MyHint