### PR TITLE
feat: Mod命名默认值增加“【】xxx”

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadCompDetail.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadCompDetail.xaml.vb
@@ -1,4 +1,4 @@
-﻿Public Class PageDownloadCompDetail
+Public Class PageDownloadCompDetail
     Private CompItem As MyCompItem = Nothing
 
 #Region "加载器"
@@ -367,8 +367,10 @@
                         Case 0
                             FileName = $"[{ChineseName}] {File.FileName}"
                         Case 1
-                            FileName = $"{ChineseName}-{File.FileName}"
+                            FileName = $"【{ChineseName}】{File.FileName}"
                         Case 2
+                            FileName = $"{ChineseName}-{File.FileName}"
+                        Case 3
                             FileName = $"{File.FileName}-{ChineseName}"
                         Case Else
                             FileName = File.FileName

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupSystem.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupSystem.xaml
@@ -1,4 +1,4 @@
-﻿<local:MyPageRight
+<local:MyPageRight
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="clr-namespace:PCL" xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -66,6 +66,7 @@
                         <local:MyComboBox Grid.Row="0" x:Name="ComboDownloadTranslate" Grid.ColumnSpan="2" Tag="ToolDownloadTranslate" Grid.Column="1" 
                                           ToolTip="下载 Mod 时，Mod 的默认文件名中，中文译名应该放在哪个位置">
                             <local:MyComboBoxItem Content="译名位于文件名开头：[遗物] relics-0.1.14" IsSelected="True" />
+                            <local:MyComboBoxItem Content="译名位于文件名开头：【遗物】relics-0.1.14" />
                             <local:MyComboBoxItem Content="译名位于文件名开头：遗物-relics-0.1.14" />
                             <local:MyComboBoxItem Content="译名位于文件名末尾：relics-0.1.14-遗物" />
                             <local:MyComboBoxItem Content="不添加中文译名：relics-0.1.14" />


### PR DESCRIPTION
close: #5826
![image](https://github.com/user-attachments/assets/4f422cea-0c0f-4b98-a144-77eaac9c5ec2)
注意：【】与后面的mod名称之间删去了空格，要不然间隙太大