### PR TITLE
fix(ModMinecraft): 不再显示没有 Jar 文件的版本

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModMinecraft.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModMinecraft.vb
@@ -1193,7 +1193,7 @@ OnLoaded:
                 For Each Folder As String In ReadIni(Path & "PCL.ini", "CardValue" & (i + 1), ":").Split(":")
                     If Folder = "" Then Continue For
                     Dim VersionFolder As String = $"{Path}versions\{Folder}\"
-                    If File.Exists(VersionFolder & ".pclignore") Then
+                    If File.Exists(VersionFolder & ".pclignore") OrElse Not File.Exists(VersionFolder & Folder & ".jar") Then
                         If IsFirstMcVersionListLoad Then
                             Log("[Minecraft] 清理残留的忽略项目：" & VersionFolder) '#2781
                             File.Delete(VersionFolder & ".pclignore")

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModMinecraft.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModMinecraft.vb
@@ -1193,7 +1193,7 @@ OnLoaded:
                 For Each Folder As String In ReadIni(Path & "PCL.ini", "CardValue" & (i + 1), ":").Split(":")
                     If Folder = "" Then Continue For
                     Dim VersionFolder As String = $"{Path}versions\{Folder}\"
-                    If File.Exists(VersionFolder & ".pclignore") OrElse Not File.Exists(VersionFolder & Folder & ".jar") Then
+                    If File.Exists(VersionFolder & ".pclignore") Then
                         If IsFirstMcVersionListLoad Then
                             Log("[Minecraft] 清理残留的忽略项目：" & VersionFolder) '#2781
                             File.Delete(VersionFolder & ".pclignore")
@@ -1201,6 +1201,10 @@ OnLoaded:
                             Log("[Minecraft] 跳过要求忽略的项目：" & VersionFolder)
                             Continue For
                         End If
+                    End If
+                    If Not File.Exists(VersionFolder & Folder & ".jar") Then
+                        Log("[Minecraft] 跳过没有 Jar 文件的项目：" & VersionFolder)
+                        Continue For
                     End If
                     Try
 


### PR DESCRIPTION
每次打开官启时，官启会在 versions 文件夹里创建两个文件夹（已有则不会创建），一个是当前的最新正式版，一个是当前的最新快照版
![image](https://github.com/user-attachments/assets/ab3f9254-902a-4590-bdcd-6d9854445d54)
当然，官启只是创建了这个文件夹，里面只有 Json，并没有 Jar 文件
![image](https://github.com/user-attachments/assets/fd6f930b-9292-40df-85d7-9f6686776ae9)
如果在 PCL 里选中了这个版本，启动时 PCL 会自动把游戏给下载下来
但是问题是，每次打开官启都创建这两个文件夹，久而久之，你的版本列表就会变成这样……
![image](https://github.com/user-attachments/assets/03e19989-c7bc-46b3-b296-4b248731ff6d)
本 PR 就是解决此问题的
~虽然我怎么感觉有可能会被拒呢~