### PR TITLE
修复错误分类的版本

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadClient.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadClient.xaml.vb
@@ -24,11 +24,7 @@
                     Case "snapshot"
                         Type = "预览版"
                         'Mojang 误分类
-                        If Version("id").ToString.StartsWith("1.") AndAlso
-                            Not Version("id").ToString.ToLower.Contains("combat") AndAlso
-                            Not Version("id").ToString.ToLower.Contains("rc") AndAlso
-                            Not Version("id").ToString.ToLower.Contains("experimental") AndAlso
-                            Not Version("id").ToString.ToLower.Contains("pre") Then
+                        If Version("id").ToString = "1.5" Then
                             Type = "正式版"
                             Version("type") = "release"
                         End If

--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.vb
@@ -575,11 +575,7 @@
                     Case "snapshot"
                         Type = "预览版"
                         'Mojang 误分类
-                        If Version("id").ToString.StartsWith("1.") AndAlso
-                            Not Version("id").ToString.ToLower.Contains("combat") AndAlso
-                            Not Version("id").ToString.ToLower.Contains("rc") AndAlso
-                            Not Version("id").ToString.ToLower.Contains("experimental") AndAlso
-                            Not Version("id").ToString.ToLower.Contains("pre") Then
+                        If Version("id").ToString = "1.5" Then
                             Type = "正式版"
                             Version("type") = "release"
                         End If


### PR DESCRIPTION
经查询`piston-meta`和Wiki，发现：
* 1.7.3、1.7.1、1.7、1.6.3、1.6、1.4.3、1.4.1、1.4、1.2属于“预览版”（`snapshot`），但由于此段代码被错误分类至“正式版”。
* 源类型错误的仅有1.5（实为`release`），其开发版本被称为1.5-pre。该问题可能由**正式版更新内容与开发版本相同**导致，可上报mojira，但~~或许不会修复~~。

此PR就此修改了相关代码。

论：~~原来是分类错了而不是正式版数量已达100~~，实为92（若不计入1.5，则为91）。