### PR TITLE
Fix(ModModpack):解压进度可能超过 100%

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModModpack.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModModpack.vb
@@ -115,6 +115,8 @@ Public Module ModModpack
         Dim Encode = Encoding.GetEncoding("GB18030")
         Try
 Retry:
+            '解压失败没有重置解压进度，导致可能超过 100% （#6070）
+            Loader.Progress = 0.02
             '完全不知道为啥会出现文件正在被另一进程使用的问题，总之多试试
             DeleteDirectory(InstallTemp)
             ExtractFile(FileAddress, InstallTemp, Encode, ProgressIncrementHandler:=Sub(Delta) Loader.Progress += Delta * LoaderProgressDelta)


### PR DESCRIPTION
Resolve #6070 

不太清楚一开始进度是多少，就按 PCL 一开始显示的进度（2%）来重置了