### PR TITLE
fix(ModLoader): 不应当显示的加载器的进度也被计入到显示的总进度中

### DIFF
--- a/Plain Craft Launcher 2/Modules/Base/ModLoader.vb
+++ b/Plain Craft Launcher 2/Modules/Base/ModLoader.vb
@@ -626,7 +626,7 @@ Restart:
     Public Function LoaderTaskbarProgressGet() As Double
         Try
             If Not LoaderTaskbar.Any Then Return 1
-            Return MathClamp(LoaderTaskbar.Select(Function(e) e.Progress).Average(), 0, 1)
+            Return MathClamp(LoaderTaskbar.Where(Function(lb As LoaderBase) lb.Show).Select(Function(lb As LoaderBase) lb.Progress).Average(), 0, 1)
         Catch ex As Exception
             Log(ex, "获取任务栏进度出错", LogLevel.Feedback)
             Return 0.5


### PR DESCRIPTION
- Fixes #6135