### PR TITLE
fix(PageDownloadOptiFine.xaml): 修复 OptiFine 简介病句

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadOptiFine.xaml
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadOptiFine.xaml
@@ -8,7 +8,7 @@
         <StackPanel Orientation="Vertical" Margin="5">
             <local:MyCard Margin="20,20,20,0" Grid.IsSharedSizeScope="True" Title="OptiFine 简介" x:Name="CardTip">
                 <StackPanel Margin="25,40,15,20">
-                    <TextBlock Name="LabConnect" Margin="0,0,0,11" Text="OptiFine 又称为高清修复，以允许安装光影、使用高清材质、提高游戏性能，但与 Mod 的兼容性不佳。" TextWrapping="Wrap" />
+                    <TextBlock Name="LabConnect" Margin="0,0,0,11" Text="OptiFine 又称为高清修复，允许安装光影、使用高清材质、提高游戏性能，但与 Mod 的兼容性不佳。" TextWrapping="Wrap" />
                     <Grid Height="35">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" SharedSizeGroup="Button" />


### PR DESCRIPTION
“以”用法错误，如需用“以”需在前方添加动词，故此删去。

<details>
  <summary>一段来自 ChatGPT 的解释</summary>
  你指出的这个句子中，“以允许安装光影……”中的“以”的用法确实不恰当，是病句。

### 问题分析：
原句：
> “OptiFine 又称为高清修复，以允许安装光影、使用高清材质、提高游戏性能，但与 Mod 的兼容性不佳。”

这里的问题在于，“以”在现代汉语中常常用在目的状语的结构中，一般表示“为了……而……”的含义，搭配的动词多为动作动词或明确的目标动作（如：“以提高性能”，“以适应需求”）。

但“允许安装光影、使用高清材质、提高游戏性能”本身更倾向于说明功能或效果，而不是表达一个特定的“目的”。“允许安装”这样的表达与“以”搭配显得别扭，“允许”并非主语为了达成目的主动实施的动作，而是功能或特性本身所具备的能力。

### 建议修改：
可以去掉“以”，或者换成更合适的表达：

- 方式一（去掉“以”）：
  > OptiFine 又称为高清修复，允许安装光影、使用高清材质、提高游戏性能，但与 Mod 的兼容性不佳。

- 方式二（改用目的状语）：
  > OptiFine 又称为高清修复，用以提高游戏性能、支持高清材质与光影效果，但与 Mod 的兼容性不佳。

推荐采用方式一，更自然清晰。

### 结论：
原句中“以”的用法确实是病句，应当修改或去掉。
</details>