### PR TITLE
typo: unexcepted "s" appear in shader filter options

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageDownloadShader.xaml
+++ b/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageDownloadShader.xaml
@@ -27,7 +27,7 @@
         <local:MyComboBoxItem Margin="15,0,0,0" Content="高" Tag="/high" />
 
         <local:MyComboBoxItem Content="加载器" IsEnabled="False" />
-        <local:MyComboBoxItem Margin="15,0,0,0" Content="原版可用s" Tag="/vanilla" ToolTip="作为资源包加载，可以直接在原版游戏里使用。" ToolTipService.HorizontalOffset="70" />
+        <local:MyComboBoxItem Margin="15,0,0,0" Content="原版可用" Tag="/vanilla" ToolTip="作为资源包加载，可以直接在原版游戏里使用。" ToolTipService.HorizontalOffset="70" />
         <local:MyComboBoxItem Margin="15,0,0,0" Content="Iris" Tag="/iris" />
         <local:MyComboBoxItem Margin="15,0,0,0" Content="OptiFine" Tag="/optifine" />
     </local:PageComp>


### PR DESCRIPTION
fix #6438