### PR TITLE
为IssueTemplate添加混淆的选项

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug1.yml
+++ b/.github/ISSUE_TEMPLATE/bug1.yml
@@ -12,6 +12,8 @@ body:
       required: false
     - label: "**我已尝试使用 HMCL 启动，HMCL 没有出现问题。** 如果 HMCL 也无法启动就不是 PCL 导致的问题，请 **不要** 提交反馈。[下载 HMCL](https://hmcl.huangyuhui.net/download)"
       required: true
+    - label: "我仔细阅读了所有这些选项，并且了解不需要勾选这个选项，而且了解到如果勾选了，开发者可能根本不会理会这个Bug。"
+      required: false
     - label: "我已在 [Issues 页面](https://github.com/Hex-Dragon/PCL2/issues?q=is%3Aissue+) 和 [常见&难检反馈及问题列表](https://github.com/Hex-Dragon/PCL2/discussions/1930) 中搜索，确认了这一 Bug 未被提交过。"
       required: true
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug2.yml
+++ b/.github/ISSUE_TEMPLATE/bug2.yml
@@ -12,6 +12,8 @@ body:
       required: false
     - label: "我知晓大多数此类问题都是网络环境不佳导致的，但我确实认为我的问题可能是 PCL 导致的，和网络环境无关。"
       required: true
+    - label: "我仔细阅读了所有这些选项，并且了解不需要勾选这个选项，而且了解到如果勾选了，开发者可能根本不会理会这个Bug。"
+      required: false
     - label: "我已在 [Issues 页面](https://github.com/Hex-Dragon/PCL2/issues?q=is%3Aissue+) 和 [常见&难检反馈及问题列表](https://github.com/Hex-Dragon/PCL2/discussions/1930) 中搜索，确认了这一 Bug 未被提交过。"
       required: true
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug9.yml
+++ b/.github/ISSUE_TEMPLATE/bug9.yml
@@ -10,6 +10,8 @@ body:
     options:
     - label: "我已在 [Issues 页面](https://github.com/Hex-Dragon/PCL2/issues?q=is%3Aissue+) 和 [常见&难检反馈及问题列表](https://github.com/Hex-Dragon/PCL2/discussions/1930) 中搜索，确认了这一 Bug 未被提交过。"
       required: true
+    - label: "我仔细阅读了所有这些选项，并且了解不需要勾选这个选项，而且了解到如果勾选了，开发者可能根本不会理会这个Bug。"
+      required: false
 - type: textarea
   id: "yml-2"
   attributes:

--- a/.github/ISSUE_TEMPLATE/ch.yml
+++ b/.github/ISSUE_TEMPLATE/ch.yml
@@ -12,6 +12,8 @@ body:
       required: true
     - label: "我已查看 [功能投票页面](https://github.com/Hex-Dragon/PCL2/discussions/categories/%E5%8A%9F%E8%83%BD%E6%8A%95%E7%A5%A8/)，确认了这一建议未在投票列表中。"
       required: true
+    - label: "我仔细阅读了所有这些选项，并且了解不需要勾选这个选项，而且了解到如果勾选了，开发者可能根本不会理会这个优化建议。"
+      required: false
 - type: textarea
   id: "yml-2"
   attributes:

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -12,6 +12,8 @@ body:
       required: true
     - label: "我已查看 [功能投票页面](https://github.com/Hex-Dragon/PCL2/discussions/categories/%E5%8A%9F%E8%83%BD%E6%8A%95%E7%A5%A8/)，确认了这一提案未在投票列表中。"
       required: true
+    - label: "我仔细阅读了所有这些选项，并且了解不需要勾选这个选项，而且了解到如果勾选了，开发者可能根本不会理会这个提案。"
+      required: false
     - label: "我知晓还没做的新功能真的太多了，忙不过来，所以新功能提案几乎不会被处理，也不建议再提交新功能提案 qwq……"
       required: true
 - type: textarea


### PR DESCRIPTION
如题，更改详情可见diff。这样可以避免一些提交者把检查项当许可条款的问题……但不是全部……